### PR TITLE
Require API v40

### DIFF
--- a/.changes/v1.0.0/4-features.md
+++ b/.changes/v1.0.0/4-features.md
@@ -1,4 +1,4 @@
-* **New Resource:** `vcfa_nsx_manager` to manage VMware Cloud Foundation Automation NSX Managers
+- **New Resource:** `vcfa_nsx_manager` to manage VMware Cloud Foundation Automation NSX Managers
   [GH-4]
-* **New Data Source:** `vcfa_nsx_manager` to read VMware Cloud Foundation Automation NSX Managers
+- **New Data Source:** `vcfa_nsx_manager` to read VMware Cloud Foundation Automation NSX Managers
   [GH-4]

--- a/.changes/v1.0.0/6-notes.md
+++ b/.changes/v1.0.0/6-notes.md
@@ -1,0 +1,1 @@
+- Use only API v40+ [GH-6]

--- a/vcfa/config.go
+++ b/vcfa/config.go
@@ -23,6 +23,8 @@ func init() {
 	}
 }
 
+var minVcfaApiVersion = "40.0"
+
 type Config struct {
 	User                    string
 	Password                string
@@ -176,6 +178,7 @@ func (c *Config) Client() (*VCDClient, error) {
 	vcdClient := &VCDClient{
 		VCDClient: govcd.NewVCDClient(*authUrl, c.InsecureFlag,
 			govcd.WithHttpUserAgent(userAgent),
+			govcd.WithAPIVersion(minVcfaApiVersion),
 		),
 		SysOrg:       c.SysOrg,
 		Org:          c.Org,
@@ -185,11 +188,6 @@ func (c *Config) Client() (*VCDClient, error) {
 	err = ProviderAuthenticate(vcdClient.VCDClient, c.User, c.Password, c.Token, c.SysOrg, c.ApiToken, c.ApiTokenFile, c.ServiceAccountTokenFile)
 	if err != nil {
 		return nil, fmt.Errorf("something went wrong during authentication: %s", err)
-	}
-
-	// Require API V40 (TM starting API version) to be present
-	if vcdClient.Client.APIVCDMaxVersionIs("< 40") {
-		return nil, fmt.Errorf("unsupported API version, at least v40 required")
 	}
 
 	cachedVCDClients.Lock()

--- a/vcfa/config_test.go
+++ b/vcfa/config_test.go
@@ -754,7 +754,9 @@ func getTestVCFAFromJson(testConfig TestConfig) (*govcd.VCDClient, error) {
 		return &govcd.VCDClient{}, fmt.Errorf("could not parse Url: %s", err)
 	}
 	vcdClient := govcd.NewVCDClient(*configUrl, true,
-		govcd.WithHttpUserAgent(buildUserAgent("test", testConfig.Provider.SysOrg)))
+		govcd.WithHttpUserAgent(buildUserAgent("test", testConfig.Provider.SysOrg)),
+		govcd.WithAPIVersion(minVcfaApiVersion),
+	)
 	return vcdClient, nil
 }
 


### PR DESCRIPTION
Tests passed, logs contain only 40.0