### PR TITLE
Add vcfa_org_oidc resource and data source

### DIFF
--- a/.changes/v1.0.0/14-features.md
+++ b/.changes/v1.0.0/14-features.md
@@ -1,0 +1,2 @@
+* **New Resource:** `vcfa_org_oidc` to manage OpenID Connect settings for an Organization [GH-14]
+* **New Data Source:** `vcfa_org_oidc` to read OpenID Connect settings from an Organization [GH-14]

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -41,5 +41,5 @@ jobs:
       - name: No VCD references
         run: |
           set +e
-          grep --exclude-dir=.git -ERin "Director|VCD|ources\/tm|labelTm|vcd_tm" . | grep -Eiv "VCDClient|.log|govcdClient|vcdClient|GOVCD_|govcd.|/director/|directory|github|go-vcloud-director|Directories"
+          grep --exclude-dir=.git -ERin "Director|VCD|ources\/tm|labelTm|vcd_tm" . | grep -Eiv "VCDClient|.log:|govcdClient|vcdClient|GOVCD_|govcd.|/director/|directory|github|go-vcloud-director|Directories"
           if [ "$?" -eq 0 ]; then echo "ERROR: Found some VCD references"; exit 1; else exit 0; fi

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vmware/terraform-provider-vcfa
 go 1.22.3
 
 require (
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.19
@@ -20,7 +21,6 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.2 // indirect
@@ -66,3 +66,5 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/vmware/go-vcloud-director/v3 => github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250127121421-ce962533e159

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
-	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.19
+	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.20
 )
 
 require (
@@ -66,5 +66,3 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v3 => github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250127121421-ce962533e159

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250127121421-ce962533e159 h1:S7IgCDJUHBQRPNI0HtVN6+zFhVvIuohF5IJTbo3ZhlE=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250127121421-ce962533e159/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -149,8 +151,6 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.19 h1:NHrxpeebuqKYvIac/cynOhSzoK0iI9RowF0b2g00ypg=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.19/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250127121421-ce962533e159 h1:S7IgCDJUHBQRPNI0HtVN6+zFhVvIuohF5IJTbo3ZhlE=
-github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250127121421-ce962533e159/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -151,6 +149,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.20 h1:Ir+7RfT0+yD6yUAU6AV+LtJ0kyLT+pornis14qsG82s=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.20/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/vcfa/config_test.go
+++ b/vcfa/config_test.go
@@ -106,6 +106,11 @@ type TestConfig struct {
 		VcenterStorageProfile string `json:"vcenterStorageProfile"`
 		VcenterSupervisor     string `json:"vcenterSupervisor"`
 		VcenterSupervisorZone string `json:"vcenterSupervisorZone"`
+
+		OidcServer struct {
+			Url               string `json:"url,omitempty"`
+			WellKnownEndpoint string `json:"wellKnownEndpoint,omitempty"`
+		} `json:"oidcServer"`
 	} `json:"tm,omitempty"`
 	Logging struct {
 		Enabled         bool   `json:"enabled,omitempty"`

--- a/vcfa/datasource_vcfa_org_oidc.go
+++ b/vcfa/datasource_vcfa_org_oidc.go
@@ -1,0 +1,188 @@
+package vcfa
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// datasourceVcfaOrgOidc defines the data source that reads Open ID Connect (OIDC) settings from an Organization
+func datasourceVcfaOrgOidc() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcfaOrgOidcRead,
+		Schema: map[string]*schema.Schema{
+			"org_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: fmt.Sprintf("%s ID that has the %s settings", labelVcfaOrg, labelVcfaOidc),
+			},
+			"client_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("Client ID used when talking to the %s Identity Provider", labelVcfaOidc),
+			},
+			"client_secret": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: fmt.Sprintf("Client Secret used when talking to the %s Identity Provider", labelVcfaOidc),
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: fmt.Sprintf("Whether %s authentication for the specified Organization is enabled or disabled", labelVcfaOidc),
+			},
+			"wellknown_endpoint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("Endpoint from the %s Identity Provider that serves all the configuration values", labelVcfaOidc),
+			},
+			"issuer_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("The issuer identifier of the %s Identity Provider", labelVcfaOidc),
+			},
+			"user_authorization_endpoint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("The user authorization endpoint of the %s Identity Provider", labelVcfaOidc),
+			},
+			"access_token_endpoint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("The access token endpoint of the %s Identity Provider", labelVcfaOidc),
+			},
+			"userinfo_endpoint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("The user info endpoint of the %s Identity Provider", labelVcfaOidc),
+			},
+			"prefer_id_token": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the claims from 'userinfo_endpoint' and the ID Token are combined (true) or not (false)",
+			},
+			"max_clock_skew_seconds": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum clock skew is the maximum allowable time difference between the client and server",
+			},
+			"scopes": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed:    true,
+				Description: fmt.Sprintf("A set of scopes used with the %s provider", labelVcfaOidc),
+			},
+			"claims_mapping": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: fmt.Sprintf("A single configuration block that contains the claim mappings used with the %s provider", labelVcfaOidc),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Email claim mapping",
+						},
+						"subject": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Subject claim mapping",
+						},
+						"last_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Last name claim mapping",
+						},
+						"first_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "First name claim mapping",
+						},
+						"full_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Full name claim mapping",
+						},
+						"groups": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Groups claim mapping",
+						},
+						"roles": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Roles claim mapping",
+						},
+					},
+				},
+			},
+			"key": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: fmt.Sprintf("One or more configuration blocks that contain the keys used with the %s Identity Provider", labelVcfaOidc),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "ID of the key",
+						},
+						"algorithm": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Algorithm of the key",
+						},
+						"certificate": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The certificate contents",
+						},
+						"expiration_date": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Expiration date for the certificate",
+						},
+					},
+				},
+			},
+			"key_refresh_endpoint": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Endpoint used to refresh the keys",
+			},
+			"key_refresh_period_hours": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The frequency of key refresh",
+			},
+			"key_refresh_strategy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Defines the strategy of key refresh",
+			},
+			"key_expire_duration_hours": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The expiration period of the key, only available if 'key_refresh_strategy=EXPIRE_AFTER'",
+			},
+			"ui_button_label": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The label of the UI button of the login screen. Only available since VCD 10.5.1",
+			},
+			"redirect_uri": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Redirect URI for this org",
+			},
+		},
+	}
+}
+
+func datasourceVcfaOrgOidcRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcfaOrgOidcRead(ctx, d, meta, "datasource")
+}

--- a/vcfa/datasource_vcfa_org_oidc.go
+++ b/vcfa/datasource_vcfa_org_oidc.go
@@ -172,7 +172,7 @@ func datasourceVcfaOrgOidc() *schema.Resource {
 			"ui_button_label": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The label of the UI button of the login screen. Only available since VCD 10.5.1",
+				Description: "The label of the UI button of the login screen",
 			},
 			"redirect_uri": {
 				Type:        schema.TypeString,

--- a/vcfa/datasource_vcfa_org_oidc.go
+++ b/vcfa/datasource_vcfa_org_oidc.go
@@ -31,7 +31,7 @@ func datasourceVcfaOrgOidc() *schema.Resource {
 			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: fmt.Sprintf("Whether %s authentication for the specified Organization is enabled or disabled", labelVcfaOidc),
+				Description: fmt.Sprintf("Whether %s authentication for the specified %s is enabled or disabled", labelVcfaOrg, labelVcfaOidc),
 			},
 			"wellknown_endpoint": {
 				Type:        schema.TypeString,

--- a/vcfa/provider.go
+++ b/vcfa/provider.go
@@ -50,6 +50,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcfa_provider_gateway":      datasourceVcfaProviderGateway(),     // 1.0
 	"vcfa_edge_cluster":          datasourceVcfaEdgeCluster(),         // 1.0
 	"vcfa_edge_cluster_qos":      datasourceVcfaEdgeClusterQos(),      // 1.0
+	"vcfa_org_oidc":              datasourceVcfaOrgOidc(),             // 1.0
 }
 
 var globalResourceMap = map[string]*schema.Resource{
@@ -63,6 +64,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcfa_content_library_item": resourceVcfaContentLibraryItem(), // 1.0
 	"vcfa_provider_gateway":     resourceVcfaProviderGateway(),    // 1.0
 	"vcfa_edge_cluster_qos":     resourceVcfaEdgeClusterQos(),     // 1.0
+	"vcfa_org_oidc":             resourceVcfaOrgOidc(),            // 1.0
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcfa/resource_vcfa_org_oidc.go
+++ b/vcfa/resource_vcfa_org_oidc.go
@@ -47,7 +47,7 @@ func resourceVcfaOrgOidc() *schema.Resource {
 			"enabled": {
 				Type:        schema.TypeBool,
 				Required:    true,
-				Description: fmt.Sprintf("Enables or disables %s authentication for the specified Organization", labelVcfaOidc),
+				Description: fmt.Sprintf("Enables or disables %s authentication for the specified %s", labelVcfaOidc, labelVcfaOrg),
 			},
 			"wellknown_endpoint": {
 				Type:        schema.TypeString,

--- a/vcfa/resource_vcfa_org_oidc.go
+++ b/vcfa/resource_vcfa_org_oidc.go
@@ -1,0 +1,504 @@
+package vcfa
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/go-vcloud-director/v3/govcd"
+	"github.com/vmware/go-vcloud-director/v3/types/v56"
+	"log"
+	"strings"
+	"time"
+)
+
+const labelVcfaOidc = "OpenID Connect"
+
+// resourceVcfaOrgOidc defines the resource that manages OpenID Connect (OIDC) settings for an Organization
+func resourceVcfaOrgOidc() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourceVcfaOrgOidcRead,
+		CreateContext: resourceVcfaOrgOidcCreate,
+		UpdateContext: resourceVcfaOrgOidcUpdate,
+		DeleteContext: resourceVcfaOrgOidcDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcfaOrgOidcImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"org_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: fmt.Sprintf("ID of the %s that will have the %s settings configured", labelVcfaOrg, labelVcfaOidc),
+			},
+			"client_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: fmt.Sprintf("Client ID to use when talking to the %s Identity Provider", labelVcfaOidc),
+			},
+			"client_secret": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: fmt.Sprintf("Client Secret to use when talking to the %s Identity Provider", labelVcfaOidc),
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: fmt.Sprintf("Enables or disables %s authentication for the specified Organization", labelVcfaOidc),
+			},
+			"wellknown_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: fmt.Sprintf("Endpoint from the %s Identity Provider that serves all the configuration values", labelVcfaOidc),
+			},
+			"issuer_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true, // Can be obtained with "wellknown_endpoint"
+				Description: fmt.Sprintf("The issuer identifier of the %s Identity Provider. "+
+					"If 'wellknown_endpoint' is set, this attribute overrides the obtained issuer identifier", labelVcfaOidc),
+				AtLeastOneOf: []string{"issuer_id", "wellknown_endpoint"},
+			},
+			"user_authorization_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true, // Can be obtained with "wellknown_endpoint"
+				Description: fmt.Sprintf("The user authorization endpoint of the %s Identity Provider. "+
+					"If 'wellknown_endpoint' is set, this attribute overrides the obtained user authorization endpoint", labelVcfaOidc),
+				AtLeastOneOf: []string{"user_authorization_endpoint", "wellknown_endpoint"},
+			},
+			"access_token_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true, // Can be obtained with "wellknown_endpoint"
+				Description: fmt.Sprintf("The access token endpoint of the %s Identity Provider. "+
+					"If 'wellknown_endpoint' is set, this attribute overrides the obtained access token endpoint", labelVcfaOidc),
+				AtLeastOneOf: []string{"access_token_endpoint", "wellknown_endpoint"},
+			},
+			"userinfo_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true, // Can be obtained with "wellknown_endpoint"
+				Description: fmt.Sprintf("The user info endpoint of the %s Identity Provider. "+
+					"If 'wellknown_endpoint' is set, this attribute overrides the obtained user info endpoint", labelVcfaOidc),
+				AtLeastOneOf: []string{"userinfo_endpoint", "wellknown_endpoint"},
+			},
+			"prefer_id_token": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Description: "If you want to combine claims from 'userinfo_endpoint' and the ID Token, set this to 'true'. " +
+					"The identity providers do not provide all the required claims set in 'userinfo_endpoint'." +
+					"By setting this argument to 'true', VCFA can fetch and consume claims from both sources",
+			},
+			"max_clock_skew_seconds": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  60,
+				Description: "The maximum clock skew is the maximum allowable time difference between the client and server. " +
+					"This time compensates for any small-time differences in the timestamps when verifying tokens",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+			},
+			"scopes": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+				Computed: true, // Can be obtained with "wellknown_endpoint"
+				Description: fmt.Sprintf("A set of scopes to use with the %s provider. "+
+					"They are used to authorize access to user details, by defining the permissions that the access tokens have to access user information. "+
+					"If 'wellknown_endpoint' is set, this attribute overrides the obtained scopes", labelVcfaOidc),
+			},
+			"claims_mapping": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true, // Can be obtained with "wellknown_endpoint"
+				Description: fmt.Sprintf("A single configuration block that specifies the claim mappings to use with the %s provider. "+
+					"If 'wellknown_endpoint' is set, this attribute overrides the obtained claim mappings", labelVcfaOidc),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true, // Can be obtained with "wellknown_endpoint"
+							Description: "Email claim mapping",
+						},
+						"subject": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true, // Can be obtained with "wellknown_endpoint"
+							Description: "Subject claim mapping",
+						},
+						"last_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true, // Can be obtained with "wellknown_endpoint"
+							Description: "Last name claim mapping",
+						},
+						"first_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true, // Can be obtained with "wellknown_endpoint"
+							Description: "First name claim mapping",
+						},
+						"full_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true, // Can be obtained with "wellknown_endpoint"
+							Description: "Full name claim mapping",
+						},
+						"groups": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true, // Can be obtained with "wellknown_endpoint"
+							Description: "Groups claim mapping",
+						},
+						"roles": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true, // Can be obtained with "wellknown_endpoint"
+							Description: "Roles claim mapping",
+						},
+					},
+				},
+			},
+			"key": {
+				Type:     schema.TypeSet,
+				MinItems: 1,
+				Optional: true,
+				Computed: true, // Can be obtained with "wellknown_endpoint"
+				Description: fmt.Sprintf("One or more configuration blocks that specify the keys to use with the %s Identity Provider. "+
+					"If 'wellknown_endpoint' is set, this attribute overrides the obtained keys", labelVcfaOidc),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "ID of the key",
+						},
+						"algorithm": {
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "Algorithm of the key, either RSA or EC",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"RSA", "EC"}, false)),
+						},
+						"certificate": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The certificate contents",
+						},
+						"expiration_date": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Expiration date for the certificate",
+							ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
+								if i.(string) == "" {
+									return nil // It's an optional value
+								}
+								_, err := time.Parse(time.DateOnly, i.(string))
+								if err != nil {
+									return diag.FromErr(err)
+								}
+								return nil
+							},
+						},
+					},
+				},
+			},
+			"key_refresh_endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true, // Can be obtained with "wellknown_endpoint"
+				Description: "Endpoint used to refresh the keys. If 'wellknown_endpoint' is set, then this argument" +
+					"will override the obtained endpoint",
+				RequiredWith: []string{"key_refresh_period_hours", "key_refresh_strategy"},
+			},
+			"key_refresh_period_hours": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Description:      "Defines the frequency of key refresh. Maximum is 720 hours",
+				RequiredWith:     []string{"key_refresh_endpoint"},
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 720)),
+			},
+			"key_refresh_strategy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Defines the strategy of key refresh",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"ADD", "REPLACE", "EXPIRE_AFTER"}, false)),
+				RequiredWith:     []string{"key_refresh_endpoint"},
+			},
+			"key_expire_duration_hours": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Description:      "Defines the expiration period of the key, only when 'key_refresh_strategy=EXPIRE_AFTER'. Maximum is 24 hours",
+				RequiredWith:     []string{"key_refresh_endpoint", "key_refresh_strategy"},
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(1, 24)),
+			},
+			"ui_button_label": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Customizes the label of the UI button of the login screen",
+			},
+			"redirect_uri": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Redirect URI for this org",
+			},
+		},
+	}
+}
+
+func resourceVcfaOrgOidcCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}, operation string) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgId := d.Get("org_id").(string)
+
+	org, err := vcdClient.GetAdminOrgById(orgId)
+	if err != nil {
+		return diag.Errorf("[%s %s] error searching for Org '%s': %s", labelVcfaOidc, operation, orgId, err)
+	}
+
+	// Runtime validations
+	isWellKnownEndpointUsed := d.Get("wellknown_endpoint").(string) != ""
+	scopes := d.Get("scopes").(*schema.Set).List()
+	if !isWellKnownEndpointUsed && len(scopes) == 0 {
+		return diag.Errorf("[%s %s] 'scopes' cannot be empty when a well-known endpoint is not used", labelVcfaOidc, operation)
+	}
+
+	if _, ok := d.GetOk("key_expire_duration_hours"); ok && d.Get("key_refresh_strategy") != "EXPIRE_AFTER" {
+		return diag.Errorf("[%s %s] 'key_expire_duration_hours' can only be used when 'key_refresh_strategy=EXPIRE_AFTER', but key_refresh_strategy=%s", labelVcfaOidc, operation, d.Get("key_refresh_strategy"))
+	}
+	if _, ok := d.GetOk("key_expire_duration_hours"); !ok && d.Get("key_refresh_strategy") == "EXPIRE_AFTER" {
+		return diag.Errorf("[%s %s] 'key_refresh_strategy=EXPIRE_AFTER' requires 'key_expire_duration_hours' to be set", labelVcfaOidc, operation)
+	}
+	// End of validations
+
+	settings := types.OrgOAuthSettings{
+		IssuerId:                   d.Get("issuer_id").(string),
+		Enabled:                    d.Get("enabled").(bool),
+		ClientId:                   d.Get("client_id").(string),
+		ClientSecret:               d.Get("client_secret").(string),
+		UserAuthorizationEndpoint:  d.Get("user_authorization_endpoint").(string),
+		AccessTokenEndpoint:        d.Get("access_token_endpoint").(string),
+		UserInfoEndpoint:           d.Get("userinfo_endpoint").(string),
+		MaxClockSkew:               d.Get("max_clock_skew_seconds").(int),
+		JwksUri:                    d.Get("key_refresh_endpoint").(string),
+		AutoRefreshKey:             d.Get("key_refresh_endpoint").(string) != "" && d.Get("key_refresh_strategy").(string) != "",
+		KeyRefreshStrategy:         d.Get("key_refresh_strategy").(string),
+		KeyRefreshFrequencyInHours: d.Get("key_refresh_period_hours").(int),
+		WellKnownEndpoint:          d.Get("wellknown_endpoint").(string),
+		Scope:                      convertTypeListToSliceOfStrings(scopes),
+		EnableIdTokenClaims:        addrOf(d.Get("prefer_id_token").(bool)),
+		CustomUiButtonLabel:        addrOf(d.Get("ui_button_label").(string)),
+	}
+
+	// Key configurations: OAuthKeyConfigurations
+	keyList := d.Get("key").(*schema.Set).List()
+	if len(keyList) == 0 && !isWellKnownEndpointUsed {
+		return diag.Errorf("[%s %s] error reading keys, either set a 'key' block or set 'wellknown_endpoint' to obtain this information", labelVcfaOidc, operation)
+	}
+	if len(keyList) > 0 {
+		oAuthKeyConfigurations := make([]types.OAuthKeyConfiguration, len(keyList))
+		for i, k := range keyList {
+			key := k.(map[string]interface{})
+			oAuthKeyConfigurations[i] = types.OAuthKeyConfiguration{
+				KeyId:     key["id"].(string),
+				Algorithm: key["algorithm"].(string),
+				Key:       key["certificate"].(string),
+			}
+			if key["expiration_date"].(string) != "" {
+				t, err := time.Parse(time.DateOnly, key["expiration_date"].(string))
+				if err != nil {
+					return diag.Errorf("wrong expiration date set in configuration for key '%s': %s", key["id"].(string), err)
+				}
+				oAuthKeyConfigurations[i].ExpirationDate = t.Format(time.RFC3339)
+			}
+		}
+		settings.OAuthKeyConfigurations = &types.OAuthKeyConfigurationsList{
+			OAuthKeyConfiguration: oAuthKeyConfigurations,
+		}
+	}
+
+	// Claims mapping: OIDCAttributeMapping: Subject, Email, Full name, First name and Last name are mandatory
+	claimsMapping := d.Get("claims_mapping").([]interface{})
+	if len(claimsMapping) == 0 && !isWellKnownEndpointUsed {
+		return diag.Errorf("[%s %s] error reading claims, either set a 'claims_mapping' block or set 'wellknown_endpoint' to obtain this information", labelVcfaOidc, operation)
+	}
+	if len(claimsMapping) > 0 {
+		var oidcAttributeMapping types.OIDCAttributeMapping
+		mappingEntry := claimsMapping[0].(map[string]interface{})
+		oidcAttributeMapping.SubjectAttributeName = mappingEntry["subject"].(string)
+		oidcAttributeMapping.EmailAttributeName = mappingEntry["email"].(string)
+		oidcAttributeMapping.FullNameAttributeName = mappingEntry["full_name"].(string)
+		oidcAttributeMapping.FirstNameAttributeName = mappingEntry["first_name"].(string)
+		oidcAttributeMapping.LastNameAttributeName = mappingEntry["last_name"].(string)
+		oidcAttributeMapping.GroupsAttributeName = mappingEntry["groups"].(string)
+		oidcAttributeMapping.RolesAttributeName = mappingEntry["roles"].(string)
+		settings.OIDCAttributeMapping = &oidcAttributeMapping
+	}
+
+	_, err = setOIDCSettings(org, settings)
+	if err != nil {
+		return diag.Errorf("[%s %s] Could not set OIDC settings: %s", labelVcfaOidc, operation, err)
+	}
+
+	return resourceVcfaOrgOidcRead(ctx, d, meta)
+}
+func resourceVcfaOrgOidcCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceVcfaOrgOidcCreateOrUpdate(ctx, d, meta, "create")
+}
+func resourceVcfaOrgOidcUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceVcfaOrgOidcCreateOrUpdate(ctx, d, meta, "update")
+}
+
+func resourceVcfaOrgOidcRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcfaOrgOidcRead(ctx, d, meta, "resource")
+}
+
+func genericVcfaOrgOidcRead(_ context.Context, d *schema.ResourceData, meta interface{}, origin string) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	orgId := d.Get("org_id").(string)
+
+	adminOrg, err := vcdClient.GetAdminOrgByNameOrId(orgId)
+	if govcd.ContainsNotFound(err) && origin == "resource" {
+		log.Printf("[INFO] unable to find Organization '%s' %s settings: %s. Removing from state", orgId, labelVcfaOidc, err)
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return diag.Errorf("[%s read] unable to find Organization '%s': %s", labelVcfaOidc, orgId, err)
+	}
+
+	settings, err := adminOrg.GetOpenIdConnectSettings()
+	if err != nil {
+		return diag.Errorf("[%s read] unable to read Organization '%s' OIDC settings: %s", labelVcfaOidc, orgId, err)
+	}
+
+	dSet(d, "client_id", settings.ClientId)
+	dSet(d, "client_secret", settings.ClientSecret)
+	dSet(d, "enabled", settings.Enabled)
+	dSet(d, "wellknown_endpoint", settings.WellKnownEndpoint)
+	dSet(d, "issuer_id", settings.IssuerId)
+	dSet(d, "user_authorization_endpoint", settings.UserAuthorizationEndpoint)
+	dSet(d, "access_token_endpoint", settings.AccessTokenEndpoint)
+	dSet(d, "userinfo_endpoint", settings.UserInfoEndpoint)
+	dSet(d, "max_clock_skew_seconds", settings.MaxClockSkew)
+	err = d.Set("scopes", settings.Scope)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if settings.OIDCAttributeMapping != nil {
+		claims := make([]interface{}, 1)
+		claim := map[string]interface{}{}
+		claim["email"] = settings.OIDCAttributeMapping.EmailAttributeName
+		claim["subject"] = settings.OIDCAttributeMapping.SubjectAttributeName
+		claim["last_name"] = settings.OIDCAttributeMapping.LastNameAttributeName
+		claim["first_name"] = settings.OIDCAttributeMapping.FirstNameAttributeName
+		claim["full_name"] = settings.OIDCAttributeMapping.FullNameAttributeName
+		claim["groups"] = settings.OIDCAttributeMapping.GroupsAttributeName
+		claim["roles"] = settings.OIDCAttributeMapping.RolesAttributeName
+		claims[0] = claim
+		err = d.Set("claims_mapping", claims)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if settings.OAuthKeyConfigurations != nil {
+		keyConfigurations := settings.OAuthKeyConfigurations.OAuthKeyConfiguration
+		keyConfigs := make([]map[string]interface{}, len(keyConfigurations))
+		for i, keyConfig := range keyConfigurations {
+			key := map[string]interface{}{}
+			key["id"] = keyConfig.KeyId
+			key["algorithm"] = keyConfig.Algorithm
+			key["certificate"] = keyConfig.Key
+			if keyConfig.ExpirationDate != "" {
+				t, err := time.Parse(time.RFC3339, keyConfig.ExpirationDate)
+				if err != nil {
+					return diag.Errorf("wrong expiration date received for key '%s': %s", keyConfig.KeyId, err)
+				}
+				key["expiration_date"] = t.Format(time.DateOnly)
+			}
+			keyConfigs[i] = key
+		}
+		err = d.Set("key", keyConfigs)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	dSet(d, "key_refresh_endpoint", settings.JwksUri)
+	dSet(d, "key_refresh_period_hours", settings.KeyRefreshFrequencyInHours)
+	dSet(d, "key_refresh_strategy", settings.KeyRefreshStrategy)
+	dSet(d, "key_expire_duration_hours", settings.KeyExpireDurationInHours)
+	dSet(d, "redirect_uri", settings.OrgRedirectUri)
+
+	if settings.EnableIdTokenClaims != nil {
+		dSet(d, "prefer_id_token", *settings.EnableIdTokenClaims)
+	}
+	if settings.CustomUiButtonLabel != nil {
+		dSet(d, "ui_button_label", *settings.CustomUiButtonLabel)
+	}
+
+	d.SetId(adminOrg.AdminOrg.ID)
+
+	return nil
+}
+
+func resourceVcfaOrgOidcDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	orgId := d.Get("org_id").(string)
+
+	adminOrg, err := vcdClient.GetAdminOrgById(orgId)
+	if err != nil {
+		return diag.Errorf("[%s delete] error searching for Organization '%s': %s", labelVcfaOidc, orgId, err)
+	}
+
+	err = adminOrg.DeleteOpenIdConnectSettings()
+	if err != nil {
+		return diag.Errorf("[%s delete] error deleting OIDC settings for Organization '%s': %s", labelVcfaOidc, orgId, err)
+	}
+
+	return nil
+}
+
+// resourceVcfaOrgOidcImport is responsible for importing the resource.
+// The only parameter needed is the Org identifier, which could be either the Org name or its ID
+func resourceVcfaOrgOidcImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	orgNameOrId := d.Id()
+
+	vcdClient := meta.(*VCDClient)
+	adminOrg, err := vcdClient.GetAdminOrgByNameOrId(orgNameOrId)
+	if err != nil {
+		return nil, fmt.Errorf("[%s import] error searching for Organization '%s': %s", labelVcfaOidc, orgNameOrId, err)
+	}
+
+	dSet(d, "org_id", adminOrg.AdminOrg.ID)
+
+	d.SetId(adminOrg.AdminOrg.ID)
+	return []*schema.ResourceData{d}, nil
+}
+
+// setOIDCSettings sets the given OIDC settings for the given Organization. It does this operation
+// with some tries to avoid failures due to network glitches.
+func setOIDCSettings(adminOrg *govcd.AdminOrg, settings types.OrgOAuthSettings) (*types.OrgOAuthSettings, error) {
+	tries := 0
+	var newSettings *types.OrgOAuthSettings
+	var err error
+	for tries < 5 {
+		tries++
+		newSettings, err = adminOrg.SetOpenIdConnectSettings(settings)
+		if err == nil {
+			break
+		}
+		if strings.Contains(err.Error(), "could not establish a connection") || strings.Contains(err.Error(), "connect timed out") {
+			time.Sleep(10 * time.Second)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return newSettings, nil
+}

--- a/vcfa/resource_vcfa_org_oidc.go
+++ b/vcfa/resource_vcfa_org_oidc.go
@@ -293,7 +293,6 @@ func resourceVcfaOrgOidcCreateOrUpdate(ctx context.Context, d *schema.ResourceDa
 		WellKnownEndpoint:          d.Get("wellknown_endpoint").(string),
 		Scope:                      convertTypeListToSliceOfStrings(scopes),
 		EnableIdTokenClaims:        addrOf(d.Get("prefer_id_token").(bool)),
-		CustomUiButtonLabel:        addrOf(d.Get("ui_button_label").(string)),
 	}
 
 	// Key configurations: OAuthKeyConfigurations
@@ -339,6 +338,11 @@ func resourceVcfaOrgOidcCreateOrUpdate(ctx context.Context, d *schema.ResourceDa
 		oidcAttributeMapping.GroupsAttributeName = mappingEntry["groups"].(string)
 		oidcAttributeMapping.RolesAttributeName = mappingEntry["roles"].(string)
 		settings.OIDCAttributeMapping = &oidcAttributeMapping
+	}
+
+	// Optionals
+	if v, ok := d.GetOk("ui_button_label"); ok {
+		settings.CustomUiButtonLabel = addrOf(v.(string))
 	}
 
 	_, err = setOIDCSettings(org, settings)

--- a/vcfa/resource_vcfa_org_oidc_test.go
+++ b/vcfa/resource_vcfa_org_oidc_test.go
@@ -1,4 +1,4 @@
-//go:build org || ALL || functional
+//go:build tm || org || ALL || functional
 
 package vcfa
 
@@ -34,6 +34,7 @@ func TestAccVcfaOrgOidc(t *testing.T) {
 		"PreferIdToken":     "true",
 		"UIButtonLabel":     "this is a test",
 		"SkipBinary":        "# skip-binary-test: redundant test",
+		"Tags":              "tm org",
 	}
 	testParamsNotEmpty(t, params)
 	skipIfNotSysAdmin(t)

--- a/vcfa/resource_vcfa_org_oidc_test.go
+++ b/vcfa/resource_vcfa_org_oidc_test.go
@@ -1,0 +1,239 @@
+//go:build org || ALL || functional
+
+package vcfa
+
+import (
+	_ "embed"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestAccVcfaOrgOidc(t *testing.T) {
+	preTestChecks(t)
+	oidcServerUrl := validateAndGetOidcServerUrl(t, testConfig)
+
+	orgName1 := t.Name() + "1"
+	orgName2 := t.Name() + "2"
+	orgName3 := t.Name() + "3"
+	oidcResource1 := "vcfa_org_oidc.oidc1"
+	oidcResource2 := "vcfa_org_oidc.oidc2"
+	oidcResource3 := "vcfa_org_oidc.oidc3"
+	oidcData := "data.vcfa_org_oidc.oidc_data"
+
+	var params = StringMap{
+		"OrgName1":          orgName1,
+		"OrgName2":          orgName2,
+		"OrgName3":          orgName3,
+		"WellKnownEndpoint": oidcServerUrl.String(),
+		"FuncName":          t.Name() + "-Step1",
+		"PreferIdToken":     "true",
+		"UIButtonLabel":     "this is a test",
+		"SkipBinary":        "# skip-binary-test: redundant test",
+	}
+	testParamsNotEmpty(t, params)
+	skipIfNotSysAdmin(t)
+
+	step1 := templateFill(testAccCheckVcfaOrgOidc, params)
+	params["FuncName"] = t.Name() + "-Step2"
+	step2 := templateFill(testAccCheckVcfaOrgOidc2, params)
+	params["FuncName"] = t.Name() + "-Step3"
+	params["SkipBinary"] = " "
+	step3 := templateFill(testAccCheckVcfaOrgOidc3, params)
+	if vcfaShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	debugPrintf("#[DEBUG] Configuration Step 1: %s", step1)
+	debugPrintf("#[DEBUG] Configuration Step 2: %s", step2)
+	debugPrintf("#[DEBUG] Configuration Step 3: %s", step3)
+
+	skip := false
+	skipFunc := func() (bool, error) {
+		return skip, nil
+	}
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		ErrorCheck: func(err error) error {
+			if strings.Contains(err.Error(), "could not establish a connection") {
+				skip = true
+				fmt.Printf("skipping %s as the OIDC server is not responding: %s", t.Name(), err)
+				return nil
+			}
+			return err
+		},
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckOrgDestroy(orgName1),
+			testAccCheckOrgDestroy(orgName2),
+			testAccCheckOrgDestroy(orgName3),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: step1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVcfaOrgExists("vcfa_org.org1"),
+					testAccCheckVcfaOrgExists("vcfa_org.org2"),
+					testAccCheckVcfaOrgExists("vcfa_org.org3"),
+
+					resource.TestMatchResourceAttr(oidcResource1, "redirect_uri", regexp.MustCompile(fmt.Sprintf("(?i).*=tenant:%s", orgName1))),
+					resource.TestCheckResourceAttr(oidcResource1, "client_id", "clientId"),
+					resource.TestCheckResourceAttr(oidcResource1, "client_secret", "clientSecret"),
+					resource.TestCheckResourceAttr(oidcResource1, "enabled", "true"),
+					resource.TestCheckResourceAttr(oidcResource1, "wellknown_endpoint", params["WellKnownEndpoint"].(string)),
+					resource.TestMatchResourceAttr(oidcResource1, "issuer_id", regexp.MustCompile(fmt.Sprintf("^%s://%s.*$", oidcServerUrl.Scheme, oidcServerUrl.Host))),
+					resource.TestMatchResourceAttr(oidcResource1, "user_authorization_endpoint", regexp.MustCompile(fmt.Sprintf("^%s://%s.*$", oidcServerUrl.Scheme, oidcServerUrl.Host))),
+					resource.TestMatchResourceAttr(oidcResource1, "access_token_endpoint", regexp.MustCompile(fmt.Sprintf("^%s://%s.*$", oidcServerUrl.Scheme, oidcServerUrl.Host))),
+					resource.TestMatchResourceAttr(oidcResource1, "userinfo_endpoint", regexp.MustCompile(fmt.Sprintf("^%s://%s.*$", oidcServerUrl.Scheme, oidcServerUrl.Host))),
+					resource.TestMatchResourceAttr(oidcResource1, "prefer_id_token", regexp.MustCompile("^true$")),
+					resource.TestCheckResourceAttr(oidcResource1, "max_clock_skew_seconds", "60"),
+					resource.TestMatchResourceAttr(oidcResource1, "scopes.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					resource.TestCheckResourceAttrSet(oidcResource1, "claims_mapping.0.email"),
+					resource.TestCheckResourceAttrSet(oidcResource1, "claims_mapping.0.subject"),
+					resource.TestCheckResourceAttrSet(oidcResource1, "claims_mapping.0.last_name"),
+					resource.TestCheckResourceAttrSet(oidcResource1, "claims_mapping.0.first_name"),
+					resource.TestMatchResourceAttr(oidcResource1, "key.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					resource.TestMatchResourceAttr(oidcResource1, "ui_button_label", regexp.MustCompile("^this is a test$")),
+				),
+			},
+			{
+				Config:   step2,
+				SkipFunc: skipFunc,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resourceFieldsEqual(oidcResource1, oidcResource2, []string{
+						"id", "org_id", "redirect_uri", "wellknown_endpoint", "key_refresh_endpoint",
+						"issuer_id", "claims_mapping.0.subject", "ui_button_label", "prefer_id_token",
+					}),
+					resource.TestCheckResourceAttr(oidcResource2, "issuer_id", "https://doesnotexist.broadcom.com"),
+					resource.TestCheckResourceAttr(oidcResource2, "claims_mapping.0.subject", "foo"),
+					resourceFieldsEqual(oidcResource1, oidcResource3, []string{
+						"id", "org_id", "redirect_uri", "wellknown_endpoint", "key_refresh_endpoint", "key.0.expiration_date",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(oidcResource3, "key.*", map[string]string{
+						"expiration_date": "2077-05-13",
+					}),
+				),
+			},
+			{
+				Config:   step3,
+				SkipFunc: skipFunc,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resourceFieldsEqual(oidcResource1, oidcData, nil),
+				),
+			},
+			{
+				SkipFunc:          skipFunc,
+				ResourceName:      oidcResource1,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) { return orgName1, nil },
+			},
+		},
+	})
+
+	postTestChecks(t)
+}
+
+const testAccCheckVcfaOrgOidc = `
+{{.SkipBinary}}
+resource "vcfa_org" "org1" {
+  name              = "{{.OrgName1}}"
+  full_name         = "{{.OrgName1}}"
+  description       = "{{.OrgName1}}"
+  delete_force      = true
+  delete_recursive  = true
+}
+
+resource "vcfa_org" "org2" {
+  name              = "{{.OrgName2}}"
+  full_name         = "{{.OrgName2}}"
+  description       = "{{.OrgName2}}"
+  delete_force      = true
+  delete_recursive  = true
+}
+
+resource "vcfa_org" "org3" {
+  name              = "{{.OrgName3}}"
+  full_name         = "{{.OrgName3}}"
+  description       = "{{.OrgName3}}"
+  delete_force      = true
+  delete_recursive  = true
+}
+
+resource "vcfa_org_oidc" "oidc1" {
+  org_id                      = vcfa_org.org1.id
+  enabled                     = true
+  {{.PreferIdToken}}
+  client_id                   = "clientId"
+  client_secret               = "clientSecret"
+  max_clock_skew_seconds      = 60
+  wellknown_endpoint          = "{{.WellKnownEndpoint}}"
+  {{.UIButtonLabel}}
+}
+`
+
+const testAccCheckVcfaOrgOidc2 = testAccCheckVcfaOrgOidc + `
+resource "vcfa_org_oidc" "oidc2" {
+  org_id                 = vcfa_org.org2.id
+  enabled                = true
+  client_id              = "clientId"
+  client_secret          = "clientSecret"
+  max_clock_skew_seconds = 60
+  wellknown_endpoint     = "{{.WellKnownEndpoint}}"
+  issuer_id              = "https://doesnotexist.broadcom.com"
+  claims_mapping {
+	subject = "foo"
+  }
+}
+
+resource "vcfa_org_oidc" "oidc3" {
+  org_id                      = vcfa_org.org3.id
+  enabled                     = vcfa_org_oidc.oidc1.enabled
+  {{.PreferIdToken}}
+  client_id                   = vcfa_org_oidc.oidc1.client_id
+  client_secret               = vcfa_org_oidc.oidc1.client_secret
+  max_clock_skew_seconds      = vcfa_org_oidc.oidc1.max_clock_skew_seconds
+  issuer_id                   = vcfa_org_oidc.oidc1.issuer_id
+  user_authorization_endpoint = vcfa_org_oidc.oidc1.user_authorization_endpoint
+  access_token_endpoint       = vcfa_org_oidc.oidc1.access_token_endpoint
+  userinfo_endpoint           = vcfa_org_oidc.oidc1.userinfo_endpoint
+  scopes                      = vcfa_org_oidc.oidc1.scopes
+  claims_mapping {
+    email      = vcfa_org_oidc.oidc1.claims_mapping[0].email
+    subject    = vcfa_org_oidc.oidc1.claims_mapping[0].subject
+    last_name  = vcfa_org_oidc.oidc1.claims_mapping[0].last_name
+    first_name = vcfa_org_oidc.oidc1.claims_mapping[0].first_name
+    full_name  = vcfa_org_oidc.oidc1.claims_mapping[0].full_name
+    groups     = vcfa_org_oidc.oidc1.claims_mapping[0].groups
+    roles      = vcfa_org_oidc.oidc1.claims_mapping[0].roles
+  }
+  key {
+    id              = tolist(vcfa_org_oidc.oidc1.key)[0].id
+    algorithm       = tolist(vcfa_org_oidc.oidc1.key)[0].algorithm
+    certificate     = tolist(vcfa_org_oidc.oidc1.key)[0].certificate
+	expiration_date = "2077-05-13"
+  }
+  {{.UIButtonLabel}}
+}
+`
+
+const testAccCheckVcfaOrgOidc3 = testAccCheckVcfaOrgOidc2 + `
+data "vcfa_org_oidc" "oidc_data" {
+  org_id = vcfa_org.org1.id
+}
+`
+
+func validateAndGetOidcServerUrl(t *testing.T, testConfig TestConfig) *url.URL {
+	if testConfig.Tm.OidcServer.Url == "" || testConfig.Tm.OidcServer.WellKnownEndpoint == "" {
+		t.Skip("test requires OIDC configuration")
+	}
+
+	oidcServer, err := url.Parse(testConfig.Tm.OidcServer.Url)
+	if err != nil {
+		t.Skip(t.Name() + " requires OIDC Server URL and its well-known endpoint")
+	}
+	return oidcServer.JoinPath(testConfig.Tm.OidcServer.WellKnownEndpoint)
+}

--- a/vcfa/sample_vcfa_test_config.json
+++ b/vcfa/sample_vcfa_test_config.json
@@ -46,6 +46,11 @@
     "nsxManagerPassword": "",
     "nsxManagerUrl": "https://nsxmanager.my-company.com",
     "nsxTier0Gateway": "existing-t0-gateway",
-    "nsxEdgeCluster": "existing-edge-cluster"
+    "nsxEdgeCluster": "existing-edge-cluster",
+
+    "oidcServer": {
+      "url": "URL-of-test-OIDC-server",
+      "wellKnownEndpoint": "/.well-known/openid-configuration"
+    }
   }
 }

--- a/vcfa/structure.go
+++ b/vcfa/structure.go
@@ -40,6 +40,14 @@ func convertTypeListToSliceOfStrings(param []interface{}) []string {
 	return result
 }
 
+// addrOf is a generic function to return the address of a variable
+// Note. It is mainly meant for converting literal values to pointers (e.g. `addrOf(true)`) or cases
+// for converting variables coming out straight from Terraform schema (e.g.
+// `addrOf(d.Get("name").(string))`).
+func addrOf[T any](variable T) *T {
+	return &variable
+}
+
 // extractIdsFromOpenApiReferences extracts []string with IDs from []types.OpenApiReference which contains ID and Names
 func extractIdsFromOpenApiReferences(refs []types.OpenApiReference) []string {
 	resultStrings := make([]string, len(refs))

--- a/vcfa/vcfa_common_test.go
+++ b/vcfa/vcfa_common_test.go
@@ -185,8 +185,8 @@ func testAccCheckOrgDestroy(orgName string) resource.TestCheckFunc {
 		if org != nil {
 			return fmt.Errorf("%s %s was found", labelVcfaOrg, orgName)
 		}
-		if !govcd.IsNotFound(err) {
-			return fmt.Errorf("%s %s was not destroyed", labelVcfaOrg, orgName)
+		if !govcd.ContainsNotFound(err) {
+			return fmt.Errorf("%s %s was not destroyed: %s", labelVcfaOrg, orgName, err)
 		}
 		return nil
 	}

--- a/website/docs/d/org_oidc.html.markdown
+++ b/website/docs/d/org_oidc.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "vcfa"
+page_title: "VMware Cloud Foundation Automation: vcfa_org_oidc"
+sidebar_current: "docs-vcfa-data-source-org-oidc"
+description: |-
+  Provides a data source to read the OpenID Connect (OIDC) configuration of an Organization in VMware Cloud Foundation Automation.
+---
+
+# vcfa\_org\_oidc
+
+Provides a data source to read the OpenID Connect (OIDC) configuration of an Organization in VMware Cloud Foundation Automation.
+
+## Example Usage
+
+```hcl
+data "vcfa_org" "my_org" {
+  name = "my-org"
+}
+
+data "vcfa_org_oidc" "oidc_settings" {
+  org_id = data.vcfa_org.my_org.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org_id` - (Required) - ID of the organization containing the OIDC settings
+
+## Attribute Reference
+
+All the arguments and attributes from [the `vcfa_org_oidc` resource](/providers/vmware/vcfa/latest/docs/resources/org_oidc) are available as read-only.

--- a/website/docs/r/org_oidc.html.markdown
+++ b/website/docs/r/org_oidc.html.markdown
@@ -1,0 +1,208 @@
+---
+layout: "vcfa"
+page_title: "VMware Cloud Foundation Automation: vcfa_org_oidc"
+sidebar_current: "docs-vcfa-resource-org-oidc"
+description: |-
+  Provides a resource to configure or remove OpenID Connect (OIDC) for an Organization in VMware Cloud Foundation Automation.
+---
+
+# vcfa\_org\_oidc
+
+Provides a resource to configure or remove OpenID Connect (OIDC) for an Organization in VMware Cloud Foundation Automation.
+
+## Example Usage with Well-known Configuration Endpoint
+
+The well-known configuration endpoint retrieves all the OpenID Connect settings values:
+
+```hcl
+data "vcfa_org" "my_org" {
+  name = "my-org"
+}
+
+resource "vcfa_org_oidc" "oidc" {
+  org_id                 = data.vcfa_org.my_org.id
+  enabled                = true
+  prefer_id_token        = false
+  client_id              = "clientId"
+  client_secret          = "clientSecret"
+  max_clock_skew_seconds = 60
+  wellknown_endpoint     = "https://my-idp.company.com/oidc/.well-known/openid-configuration"
+}
+```
+
+Users can override any value retrieved by the well-known configuration:
+
+```hcl
+data "vcfa_org" "my_org" {
+  name = "my-org"
+}
+
+resource "vcfa_org_oidc" "oidc" {
+  org_id                 = data.vcfa_org.my_org.id
+  enabled                = true
+  prefer_id_token        = false
+  client_id              = "clientId"
+  client_secret          = "clientSecret"
+  max_clock_skew_seconds = 60
+  wellknown_endpoint     = "https://my-idp.company.com/oidc/.well-known/openid-configuration"
+
+  # Overrides:
+  access_token_endpoint = "https://my-other-idp.company.com/oidc/token"
+  userinfo_endpoint     = "https://my-other-idp.company.com/oidc/userinfo"
+}
+```
+
+Once the OIDC settings are created, if users want to restore an overridden value to the original one given by the
+well-known configuration endpoint, they must perform an update in code to set the previous value explicitly:
+
+```hcl
+data "vcfa_org" "my_org" {
+  name = "my-org"
+}
+
+resource "vcfa_org_oidc" "oidc" {
+  org_id                 = data.vcfa_org.my_org.id
+  enabled                = true
+  prefer_id_token        = false
+  client_id              = "clientId"
+  client_secret          = "clientSecret"
+  max_clock_skew_seconds = 60
+  wellknown_endpoint     = "https://my-idp.company.com/oidc/.well-known/openid-configuration"
+
+  access_token_endpoint = "https://my-idp.company.com/oidc/token"          # Restores the previous value
+  userinfo_endpoint     = "https://my-other-idp.company.com/oidc/userinfo" # Still overridden
+}
+```
+
+In other words, removing the argument or setting it to `""` **won't** make the original value from the well-known configuration endpoint
+to be restored during updates.
+
+## Example Usage without Well-known Configuration Endpoint
+
+```hcl
+data "vcfa_org" "my_org" {
+  name = "my-org"
+}
+
+resource "vcfa_org_oidc" "oidc" {
+  org_id                      = data.vcfa_org.my_org.id
+  enabled                     = true
+  prefer_id_token             = false
+  client_id                   = "clientId"
+  client_secret               = "clientSecret"
+  max_clock_skew_seconds      = 60
+  issuer_id                   = "https://my-idp.company.com/oidc"
+  user_authorization_endpoint = "https://my-idp.company.com/oidc/authorize"
+  access_token_endpoint       = "https://my-idp.company.com/oidc/token"
+  userinfo_endpoint           = "https://my-idp.company.com/oidc/userinfo"
+  scopes                      = ["openid", "profile", "email", "address", "phone", "offline_access"]
+  claims_mapping {
+    email      = "email"
+    subject    = "sub"
+    last_name  = "family_name"
+    first_name = "given_name"
+    full_name  = "name"
+  }
+  key {
+    id              = "rsa1"
+    algorithm       = "RSA"
+    certificate     = file("certificate.pem")
+    expiration_date = "2077-05-13"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org_id` - (Required) ID of the Organization that will have the OpenID Connect settings configured. There must be only one
+  resource `vcfa_org_oidc` per `org_id`, as there is only one OpenID configuration per Organization
+* `client_id` - (Required) Client ID to use with the OIDC provider
+* `client_secret` - (Required) Client Secret to use with the OIDC provider
+* `enabled` - (Required) Either `true` or `false`, specifies whether the OIDC authentication is enabled for the given organization
+* `wellknown_endpoint` - (Optional) This endpoint retrieves the OIDC provider configuration and automatically sets
+  the following arguments, without setting them explicitly: `issuer_id`, `user_authorization_endpoint`, `access_token_endpoint`, 
+  `userinfo_endpoint`, the `claims_mapping` block, the `key` blocks, and `scopes`. These mentioned attributes will be computed, and
+  can be overridden by setting them explicitly in HCL code
+* `issuer_id` - (Optional) The issuer ID for the OIDC provider.
+  If `wellknown_endpoint` is **not** set, then this argument is **required**. Otherwise, it is **optional**.
+  This allows users to override the configuration given by `wellknown_endpoint`
+* `user_authorization_endpoint` - (Optional) The endpoint to use for authorization.
+  If `wellknown_endpoint` is **not** set, then this argument is **required**. Otherwise, it is **optional**.
+  This allows users to override the configuration given by `wellknown_endpoint`
+* `access_token_endpoint` - (Optional) The endpoint to use for access tokens.
+  If `wellknown_endpoint` is **not** set, then this argument is **required**. Otherwise, it is **optional**.
+  This allows users to override the configuration given by `wellknown_endpoint`
+* `userinfo_endpoint` - (Optional) The endpoint to use for User Info.
+  If `wellknown_endpoint` is **not** set, then this argument is **required**. Otherwise, it is **optional**.
+  This allows users to override the configuration given by `wellknown_endpoint`
+* `prefer_id_token` - (Optional) If you want to combine claims from `userinfo_endpoint` and the ID Token, set this to `true`.
+  The identity providers do not provide all the required claims set in `userinfo_endpoint`. By setting this argument to `true`,
+  VMware Cloud Foundation Automation can fetch and consume claims from both sources
+* `max_clock_skew_seconds` - (Optional) The maximum clock skew is the maximum allowable time difference between the client and server.
+  This time compensates for any small-time differences in the timestamps when verifying tokens. The **default** value is `60` seconds
+* `scopes` - (Optional) A set of scopes to use with the OIDC provider. They are used to authorize access to user details,
+  by defining the permissions that the access tokens have to access user information.
+  If `wellknown_endpoint` is **not** set, then this argument is **required**. Otherwise, it is **optional**. This allows users
+  to override the scopes given by `wellknown_endpoint`. Setting `scopes = []` will make Terraform to set the scopes provided originally
+  by the `wellknown_endpoint`
+* `claims_mapping` - (Optional) A single configuration block that specifies the claim mappings to use with the OIDC provider.
+  If `wellknown_endpoint` is **not** set, then this argument is **required**. Otherwise, it is **optional**. This allows users
+  to override the claims given by `wellknown_endpoint`. The supported claims are:
+  * `email` - Required if `wellknown_endpoint` doesn't give info about it
+  * `subject` - Required if `wellknown_endpoint` doesn't give info about it
+  * `last_name` - Required if `wellknown_endpoint` doesn't give info about it
+  * `first_name` - Required if `wellknown_endpoint` doesn't give info about it
+  * `full_name` - Required if `wellknown_endpoint` doesn't give info about it
+  * `groups` - Optional
+  * `roles` - Optional
+* `key` - (Optional) One or more configuration blocks that specify the keys to use with the OIDC provider.
+  If `wellknown_endpoint` is **not** set, then this argument is **required**. Otherwise, it is **optional**. This allows users
+  to override the keys given by `wellknown_endpoint`. Each key requires the following:
+  * `id` - Identifier of the key
+  * `algorithm` - Algorithm used by the key. Can be `RSA` or `EC`
+  * `certificate` - The contents of a PEM file to create/update the key
+  * `expiration_date` - Expiration date for the key. The accepted format is `YYYY-MM-DD`, like `2077-12-31`
+* `key_refresh_endpoint` - (Optional) Endpoint used to refresh the keys. If set, `key_refresh_period_hours` and `key_refresh_strategy` will be required.
+  If `wellknown_endpoint` is set, then this argument will override the obtained endpoint
+* `key_refresh_period_hours` - (Optional) Required if `key_refresh_endpoint` is set. Defines the frequency of key refresh. Maximum value is `720` (30 days)
+* `key_refresh_strategy` - (Optional) Required if `key_refresh_endpoint` is set. Defines the strategy of key refresh. One of `ADD`, `REPLACE`, `EXPIRE_AFTER`
+* `key_expire_duration_hours` - (Optional) Required if `key_refresh_endpoint` is set and `key_refresh_strategy=EXPIRE_AFTER`. Defines the expiration period of the key. Maximum value is `24`
+* `ui_button_label` - (Optional; VCD `10.5.1+`) Customizes the label of the UI button of the login screen
+
+## Attribute Reference
+
+* `redirect_uri` - The client configuration redirect URI used to create a client application registration with an identity provider
+  that complies with the OpenID Connect standard
+
+## Importing
+
+~> **Note:** The current implementation of Terraform import can only import resources into the state. It does not generate
+configuration. [More information.][docs-import]
+
+An existing OIDC configuration for an Org can be [imported][docs-import] into this resource via supplying the path for an Organization.
+For example, using this structure, representing an existing OIDC configuration that was **not** created using Terraform:
+
+```hcl
+data "vcfa_org" "my_org" {
+  name = "my-org"
+}
+
+resource "vcfa_org_oidc" "my_org_oidc" {
+  org_id = data.vcfa_org.my_org.id
+}
+```
+
+You can import such OIDC configuration into terraform state using one of the following commands
+
+```
+terraform import vcfa_org_oidc.my_org_oidc organization_name
+# OR
+terraform import vcfa_org_oidc.my_org_oidc organization_id
+```
+
+After that, you must expand the configuration file before you can either update or delete the OIDC configuration. Running `terraform plan`
+at this stage will show the difference between the minimal configuration file and the stored properties.
+
+[docs-import]:https://www.terraform.io/docs/import/

--- a/website/docs/r/org_oidc.html.markdown
+++ b/website/docs/r/org_oidc.html.markdown
@@ -169,7 +169,7 @@ The following arguments are supported:
 * `key_refresh_period_hours` - (Optional) Required if `key_refresh_endpoint` is set. Defines the frequency of key refresh. Maximum value is `720` (30 days)
 * `key_refresh_strategy` - (Optional) Required if `key_refresh_endpoint` is set. Defines the strategy of key refresh. One of `ADD`, `REPLACE`, `EXPIRE_AFTER`
 * `key_expire_duration_hours` - (Optional) Required if `key_refresh_endpoint` is set and `key_refresh_strategy=EXPIRE_AFTER`. Defines the expiration period of the key. Maximum value is `24`
-* `ui_button_label` - (Optional; VCD `10.5.1+`) Customizes the label of the UI button of the login screen
+* `ui_button_label` - (Optional) Customizes the label of the UI button of the login screen
 
 ## Attribute Reference
 

--- a/website/vcfa.erb
+++ b/website/vcfa.erb
@@ -75,6 +75,9 @@
             <li<%= sidebar_current("docs-vcfa-data-source-edge-cluster-qos") %>>
               <a href="/docs/providers/vcfa/d/edge_cluster_qos.html">vcfa_edge_cluster_qos</a>
             </li>
+            <li<%= sidebar_current("docs-vcfa-data-source-org-oidc") %>>
+              <a href="/docs/providers/vcfa/d/org_oidc.html">vcfa_org_oidc</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcfa-resource") %>>
@@ -109,6 +112,9 @@
             </li>
             <li<%= sidebar_current("docs-vcfa-resource-edge-cluster-qos") %>>
               <a href="/docs/providers/vcfa/r/edge_cluster_qos.html">vcfa_edge_cluster_qos</a>
+            </li>
+            <li<%= sidebar_current("docs-vcfa-resource-org-oidc") %>>
+              <a href="/docs/providers/vcfa/r/org_oidc.html">vcfa_org_oidc</a>
             </li>
            </ul>
         </li>


### PR DESCRIPTION
Add `vcfa_org_oidc` resource and data source.

To test it, a valid OIDC server is required:

```
"oidcServer": {
      "url": "https://my-oidc-server:443/oidc",
      "wellKnownEndpoint": "/.well-known/openid-configuration"
}
```