### PR TITLE
Add vcfa_org_ldap resource and data source

### DIFF
--- a/.changes/v1.0.0/26-features.md
+++ b/.changes/v1.0.0/26-features.md
@@ -1,0 +1,2 @@
+- **New Resource:** `vcfa_org_ldap` to manage LDAP settings of Organizations [GH-26]
+- **New Data Source:** `vcfa_org_ldap` to read LDAP settings of Organizations [GH-26]

--- a/go.mod
+++ b/go.mod
@@ -66,3 +66,5 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/vmware/go-vcloud-director/v3 => github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250130124556-ce5a66802834

--- a/go.mod
+++ b/go.mod
@@ -67,4 +67,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/vmware/go-vcloud-director/v3 => github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250130124556-ce5a66802834
+replace github.com/vmware/go-vcloud-director/v3 => github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250130134147-f01d543cc41b

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250130124556-ce5a66802834 h1:LJf5yekkvZpUW4NdbGg6ahAK5v+O2lQ2s48z56TV/QA=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250130124556-ce5a66802834/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -149,8 +151,6 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.23 h1:GhQhlULBs/7oetCZ2IFvQfH7OqEo6Q5r9GT6v5YgZOQ=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.23/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250130124556-ce5a66802834 h1:LJf5yekkvZpUW4NdbGg6ahAK5v+O2lQ2s48z56TV/QA=
-github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250130124556-ce5a66802834/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250130134147-f01d543cc41b h1:rb5H9kV/+AS3xS0+vjLQfM0Ek2ExPpLRrRN+EEmfdv8=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250130134147-f01d543cc41b/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/vcfa/datasource_vcfa_org_ldap.go
+++ b/vcfa/datasource_vcfa_org_ldap.go
@@ -113,7 +113,7 @@ var datasourceLdapGroupAttributes = &schema.Schema{
 
 func datasourceVcfaOrgLdap() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: datasourceVcdOrgLdapRead,
+		ReadContext: datasourceVcfaOrgLdapRead,
 		Schema: map[string]*schema.Schema{
 			"org_id": {
 				Type:        schema.TypeString,
@@ -185,6 +185,6 @@ func datasourceVcfaOrgLdap() *schema.Resource {
 	}
 }
 
-func datasourceVcdOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func datasourceVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return genericVcfaOrgLdapRead(ctx, d, meta, "datasource")
 }

--- a/vcfa/datasource_vcfa_org_ldap.go
+++ b/vcfa/datasource_vcfa_org_ldap.go
@@ -1,0 +1,190 @@
+package vcfa
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// datasourceLdapUserAttributes defines the elements of types.OrgLdapUserAttributes
+// The field names are the ones used in the GUI, with a comment to indicate which structure field each one corresponds to
+var datasourceLdapUserAttributes = &schema.Schema{
+	Type:        schema.TypeList,
+	Computed:    true,
+	Description: "Custom settings when `ldap_mode` is CUSTOM",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_class": { // ObjectClass
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP objectClass of which imported users are members. For example, user or person",
+			},
+			"unique_identifier": { // ObjectIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use as the unique identifier for a user. For example, objectGuid",
+			},
+			"username": { // Username
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use when looking up a user name to import. For example, userPrincipalName or samAccountName",
+			},
+			"email": { // Email
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's email address. For example, mail",
+			},
+			"display_name": { // FullName
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's full name. For example, displayName",
+			},
+			"given_name": { // GivenName
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's given name. For example, givenName",
+			},
+			"surname": { // Surname
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's surname. For example, sn",
+			},
+			"telephone": { // Telephone
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's telephone number. For example, telephoneNumber",
+			},
+			"group_membership_identifier": { // GroupMembershipIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute that identifies a user as a member of a group. For example, dn",
+			},
+			"group_back_link_identifier": { // GroupBackLinkIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute that returns the identifiers of all the groups of which the user is a member",
+			},
+		},
+	},
+}
+
+// datasourceLdapGroupAttributes defines the elements of types.OrgLdapGroupAttributes
+// The field names are the ones used in the GUI, with a comment to indicate which structure field each one corresponds to
+var datasourceLdapGroupAttributes = &schema.Schema{
+	Type:        schema.TypeList,
+	Computed:    true,
+	Description: "Custom settings when `ldap_mode` is CUSTOM",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_class": { // ObjectClass
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP objectClass of which imported groups are members. For example, group",
+			},
+			"unique_identifier": { // ObjectIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use as the unique identifier for a group. For example, objectGuid",
+			},
+			"name": { // GroupName
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the group name. For example, cn",
+			},
+			"membership": { // Membership
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use when getting the members of a group. For example, member",
+			},
+			"group_membership_identifier": { // MembershipIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute that identifies a group as a member of another group. For example, dn",
+			},
+			"group_back_link_identifier": { // BackLinkIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP group attribute used to identify a group member",
+			},
+		},
+	},
+}
+
+func datasourceVcfaOrgLdap() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdOrgLdapRead,
+		Schema: map[string]*schema.Schema{
+			"org_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Organization ID",
+			},
+			"ldap_mode": { // OrgLdapMode
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of LDAP settings (one of NONE, SYSTEM, CUSTOM)",
+			},
+			"custom_user_ou": { // CustomUsersOu
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "If ldap_mode is SYSTEM, specifies a LDAP attribute=value pair to use for OU (organizational unit)",
+			},
+			"custom_settings": { // CustomOrgLdapSettings
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Custom settings when `ldap_mode` is CUSTOM",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server": { // Hostname
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "host name or IP of the LDAP server",
+						},
+						"port": { // Port
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Port number for LDAP service",
+						},
+						"authentication_method": { // AuthenticationMechanism
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "authentication method: one of SIMPLE, MD5DIGEST, NTLM",
+						},
+						"connector_type": { // ConnectorType
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "type of connector: one of OPEN_LDAP, ACTIVE_DIRECTORY",
+						},
+						"base_distinguished_name": { //SearchBase
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "LDAP search base",
+						},
+						"is_ssl": { // IsSsl
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "True if the LDAP service requires an SSL connection",
+						},
+						"username": { // Username
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Username to use when logging in to LDAP, specified using LDAP attribute=value pairs (for example: cn="ldap-admin", c="example", dc="com")`,
+						},
+						"password": { // Password
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Password for the user identified by UserName. This value is never returned by GET. It is inspected on create and modify. On modify, the absence of this element indicates that the password should not be changed`,
+						},
+						"user_attributes":  datasourceLdapUserAttributes,
+						"group_attributes": datasourceLdapGroupAttributes,
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceVcdOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcfaOrgLdapRead(ctx, d, meta, "datasource")
+}

--- a/vcfa/provider.go
+++ b/vcfa/provider.go
@@ -59,6 +59,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcfa_role":                            datasourceVcfaRole(),                        // 1.0
 	"vcfa_global_role":                     datasourceVcfaGlobalRole(),                  // 1.0
 	"vcfa_certificate":                     datasourceVcfaCertificate(),                 // 1.0
+	"vcfa_org_ldap":                        datasourceVcfaOrgLdap(),                     // 1.0
 }
 
 var globalResourceMap = map[string]*schema.Resource{
@@ -81,6 +82,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcfa_global_role":                     resourceVcfaGlobalRole(),                  // 1.0
 	"vcfa_api_token":                       resourceVcfaApiToken(),                    // 1.0
 	"vcfa_certificate":                     resourceVcfaCertificate(),                 // 1.0
+	"vcfa_org_ldap":                        resourceVcfaOrgLdap(),                     // 1.0
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcfa/resource_vcd_org_ldap_test.go
+++ b/vcfa/resource_vcd_org_ldap_test.go
@@ -42,7 +42,8 @@ func TestAccVcfaOrgLdap(t *testing.T) {
 	ldapDatasourceDef := "data.vcfa_org_ldap.ldap-ds"
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckOrgLdapDestroy(ldapResourceDef),
+		// TODO: TM: Check LDAP is destroyed before Organization is
+		// CheckDestroy:      testAccCheckOrgLdapDestroy(ldapResourceDef),
 		Steps: []resource.TestStep{
 			{
 				Config: configText,
@@ -107,35 +108,6 @@ func testAccCheckOrgLdapExists(identifier string) resource.TestCheckFunc {
 			return fmt.Errorf("resource %s not configured", identifier)
 		}
 		return nil
-	}
-}
-
-func testAccCheckOrgLdapDestroy(identifier string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[identifier]
-		if !ok {
-			return fmt.Errorf("not found: %s", identifier)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no %s ID is set", labelVcfaOrg)
-		}
-
-		conn := testAccProvider.Meta().(*VCDClient)
-
-		tmOrg, err := conn.GetTmOrgById(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-		config, err := tmOrg.GetLdapConfiguration()
-		if err != nil {
-			return err
-		}
-		if config.OrgLdapMode != "NONE" {
-			return fmt.Errorf("resource %s still configured", identifier)
-		}
-		return nil
-
 	}
 }
 

--- a/vcfa/resource_vcd_org_ldap_test.go
+++ b/vcfa/resource_vcd_org_ldap_test.go
@@ -37,10 +37,9 @@ func TestAccVcfaOrgLdap(t *testing.T) {
 	debugPrintf("#[DEBUG] CONFIGURATION Resource for Organization LDAP (Custom): %s\n", configText)
 	debugPrintf("#[DEBUG] CONFIGURATION Data source: %s\n", configTextDS)
 
-	orgDef := "vcd_org.org1"
-	ldapResourceDef := "vcd_org_ldap.ldap"
-	ldapDatasourceDef := "data.vcd_org_ldap.ldap-ds"
-	// Note: don't run this test in parallel, as it would clash with TestAccVcdOrgGroup
+	orgDef := "vcfa_org.org1"
+	ldapResourceDef := "vcfa_org_ldap.ldap"
+	ldapDatasourceDef := "data.vcfa_org_ldap.ldap-ds"
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckOrgLdapDestroy(ldapResourceDef),
@@ -147,8 +146,8 @@ resource "vcfa_org" "org1" {
   description  = "{{.Org}}"
 }
 
-resource "vcd_org_ldap" "ldap" {
-  org_id    = vcd_org.org1.id
+resource "vcfa_org_ldap" "ldap" {
+  org_id    = vcfa_org.org1.id
   ldap_mode = "CUSTOM"
   custom_settings {
     server                  = "{{.LdapServer}}"
@@ -186,8 +185,8 @@ resource "vcd_org_ldap" "ldap" {
 `
 
 const testAccVcfaOrgLdapDS = testAccVcfaOrgLdap + `
-data "vcd_org_ldap" "ldap-ds" {
-  org_id = vcd_org.org1.id
-  depends_on = [vcd_org_ldap.{{.OrgName}}]
+data "vcfa_org_ldap" "ldap-ds" {
+  org_id = vcfa_org.org1.id
+  depends_on = [vcfa_org_ldap.{{.OrgName}}]
 }
 `

--- a/vcfa/resource_vcd_org_ldap_test.go
+++ b/vcfa/resource_vcd_org_ldap_test.go
@@ -1,0 +1,193 @@
+//go:build ldap || org || ALL || functional
+
+package vcfa
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccVcfaOrgLdap(t *testing.T) {
+	preTestChecks(t)
+	skipIfNotSysAdmin(t)
+
+	var params = StringMap{
+		"Org":        testConfig.Tm.Org,
+		"LdapServer": regexp.MustCompile(`https?://`).ReplaceAllString(testConfig.Tm.VcenterUrl, ""),
+		"Password":   testConfig.Tm.VcenterPassword,
+		"Tags":       "ldap org",
+	}
+	testParamsNotEmpty(t, params)
+
+	params["FuncName"] = t.Name()
+	configText := templateFill(testAccVcfaOrgLdap, params)
+
+	// TODO: TM: Missing System test
+
+	params["FuncName"] = t.Name() + "-DS"
+	configTextDS := templateFill(testAccVcfaOrgLdapDS, params)
+	if vcfaShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	debugPrintf("#[DEBUG] CONFIGURATION Resource for Organization LDAP (Custom): %s\n", configText)
+	debugPrintf("#[DEBUG] CONFIGURATION Data source: %s\n", configTextDS)
+
+	orgDef := "vcd_org.org1"
+	ldapResourceDef := "vcd_org_ldap.ldap"
+	ldapDatasourceDef := "data.vcd_org_ldap.ldap-ds"
+	// Note: don't run this test in parallel, as it would clash with TestAccVcdOrgGroup
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckOrgLdapDestroy(ldapResourceDef),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgLdapExists(ldapResourceDef),
+					resource.TestCheckResourceAttr(orgDef, "name", params["Org"].(string)),
+					resource.TestCheckResourceAttr(ldapResourceDef, "ldap_mode", "CUSTOM"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.server", params["LdapServer"].(string)),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.authentication_method", "SIMPLE"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.connector_type", "OPEN_LDAP"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.user_attributes.0.object_class", "inetOrgPerson"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.group_attributes.0.object_class", "group"),
+					resource.TestCheckResourceAttrPair(orgDef, "id", ldapResourceDef, "org_id"),
+				),
+			},
+			{
+				Config: configTextDS,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgLdapExists(ldapResourceDef),
+					resource.TestCheckResourceAttrPair(ldapResourceDef, "org_id", ldapDatasourceDef, "org_id"),
+					resource.TestCheckResourceAttrPair(ldapResourceDef, "ldap_mode", ldapDatasourceDef, "ldap_mode"),
+					resource.TestCheckResourceAttrPair(ldapResourceDef, "custom_settings.0.server", ldapDatasourceDef, "custom_settings.0.server"),
+					resource.TestCheckResourceAttrPair(ldapResourceDef, "custom_settings.0.authentication_method", ldapDatasourceDef, "custom_settings.0.authentication_method"),
+					resource.TestCheckResourceAttrPair(ldapResourceDef, "custom_settings.0.connector_type", ldapDatasourceDef, "custom_settings.0.connector_type"),
+					resource.TestCheckResourceAttrPair(ldapResourceDef, "custom_settings.0.user_attributes.0.object_class", ldapDatasourceDef, "custom_settings.0.user_attributes.0.object_class"),
+					resource.TestCheckResourceAttrPair(ldapResourceDef, "custom_settings.0.group_attributes.0.object_class", ldapDatasourceDef, "custom_settings.0.group_attributes.0.object_class"),
+				),
+			},
+			{
+				ResourceName:      ldapResourceDef,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) { return testConfig.Tm.Org, nil },
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+func testAccCheckOrgLdapExists(identifier string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[identifier]
+		if !ok {
+			return fmt.Errorf("not found: %s", identifier)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no %s ID is set", labelVcfaOrg)
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		tmOrg, err := conn.GetTmOrgById(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		config, err := tmOrg.GetLdapConfiguration()
+		if err != nil {
+			return err
+		}
+		if config.OrgLdapMode == "NONE" {
+			return fmt.Errorf("resource %s not configured", identifier)
+		}
+		return nil
+	}
+}
+
+func testAccCheckOrgLdapDestroy(identifier string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[identifier]
+		if !ok {
+			return fmt.Errorf("not found: %s", identifier)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no %s ID is set", labelVcfaOrg)
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		tmOrg, err := conn.GetTmOrgById(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		config, err := tmOrg.GetLdapConfiguration()
+		if err != nil {
+			return err
+		}
+		if config.OrgLdapMode != "NONE" {
+			return fmt.Errorf("resource %s still configured", identifier)
+		}
+		return nil
+
+	}
+}
+
+const testAccVcfaOrgLdap = `
+resource "vcfa_org" "org1" {
+  name         = "{{.Org}}"
+  display_name = "{{.Org}}"
+  description  = "{{.Org}}"
+}
+
+resource "vcd_org_ldap" "ldap" {
+  org_id    = vcd_org.org1.id
+  ldap_mode = "CUSTOM"
+  custom_settings {
+    server                  = "{{.LdapServer}}"
+    port                    = 389
+    is_ssl                  = false
+    username                = "cn=Administrator,cn=Users,dc=vsphere,dc=local"
+    password                = "{{.Password}}"
+    authentication_method   = "SIMPLE"
+    base_distinguished_name = "dc=vsphere,dc=local"
+    connector_type          = "OPEN_LDAP"
+    user_attributes {
+      object_class                = "inetOrgPerson"
+      unique_identifier           = "uid"
+      display_name                = "cn"
+      username                    = "uid"
+      given_name                  = "givenName"
+      surname                     = "sn"
+      telephone                   = "telephoneNumber"
+      group_membership_identifier = "dn"
+      email                       = "mail"
+    }
+    group_attributes {
+      name                        = "cn"
+      object_class                = "group"
+      membership                  = "member"
+      unique_identifier           = "cn"
+      group_membership_identifier = "dn"
+    }
+  }
+  lifecycle {
+    # password value does not get returned by GET
+    ignore_changes = [custom_settings[0].password]
+  }
+}
+`
+
+const testAccVcfaOrgLdapDS = testAccVcfaOrgLdap + `
+data "vcd_org_ldap" "ldap-ds" {
+  org_id = vcd_org.org1.id
+  depends_on = [vcd_org_ldap.{{.OrgName}}]
+}
+`

--- a/vcfa/resource_vcd_org_ldap_test.go
+++ b/vcfa/resource_vcd_org_ldap_test.go
@@ -187,6 +187,6 @@ resource "vcfa_org_ldap" "ldap" {
 const testAccVcfaOrgLdapDS = testAccVcfaOrgLdap + `
 data "vcfa_org_ldap" "ldap-ds" {
   org_id = vcfa_org.org1.id
-  depends_on = [vcfa_org_ldap.{{.OrgName}}]
+  depends_on = [vcfa_org_ldap.ldap]
 }
 `

--- a/vcfa/resource_vcfa_org_ldap.go
+++ b/vcfa/resource_vcfa_org_ldap.go
@@ -212,7 +212,7 @@ func resourceVcfaOrgLdap() *schema.Resource {
 func resourceVcfaOrgLdapCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}, origin string) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 	if !vcdClient.Client.IsSysAdmin {
-		return diag.Errorf("resource vcd_org_ldap requires System administrator privileges")
+		return diag.Errorf("resource vcfa_org_ldap requires System administrator privileges")
 	}
 	orgId := d.Get("org_id").(string)
 
@@ -243,7 +243,7 @@ func resourceVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta i
 func genericVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}, origin string) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 	if !vcdClient.Client.IsSysAdmin {
-		return diag.Errorf("resource vcd_org_ldap requires System administrator privileges")
+		return diag.Errorf("resource vcfa_org_ldap requires System administrator privileges")
 	}
 	orgId := d.Get("org_id").(string)
 
@@ -320,7 +320,7 @@ func resourceVcfaOrgLdapUpdate(ctx context.Context, d *schema.ResourceData, meta
 func resourceVcfaOrgLdapDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 	if !vcdClient.Client.IsSysAdmin {
-		return diag.Errorf("resource vcd_org_ldap requires System administrator privileges")
+		return diag.Errorf("resource vcfa_org_ldap requires System administrator privileges")
 	}
 	orgId := d.Get("org_id").(string)
 
@@ -412,7 +412,7 @@ func fillLdapSettings(d *schema.ResourceData) (*types.OrgLdapSettingsType, error
 // The d.ID() field as being passed from `terraform import _resource_name_ _the_id_string_ requires
 // a name based dot-formatted path to the object to lookup the object and sets the id of object.
 // `terraform import` automatically performs `refresh` operation which loads up all other fields.
-// For this resource, the import path is just the org name (or Org ID).
+// For this resource, the import path is just the org name.
 //
 // Example import path (id): orgName
 func resourceVcfaOrgLdapImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/vcfa/resource_vcfa_org_ldap.go
+++ b/vcfa/resource_vcfa_org_ldap.go
@@ -1,0 +1,431 @@
+package vcfa
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/go-vcloud-director/v3/govcd"
+	"github.com/vmware/go-vcloud-director/v3/types/v56"
+)
+
+// resourceLdapUserAttributes defines the elements of types.OrgLdapUserAttributes
+// The field names are the ones used in the GUI, with a comment to indicate which API field each one corresponds to
+var resourceLdapUserAttributes = &schema.Schema{
+	Type:        schema.TypeList,
+	Required:    true,
+	MaxItems:    1,
+	Description: "User settings when `ldap_mode` is CUSTOM",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_class": { // ObjectClass
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP objectClass of which imported users are members. For example, user or person",
+			},
+			"unique_identifier": { // ObjectIdentifier
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use as the unique identifier for a user. For example, objectGuid",
+			},
+			"username": { // Username
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use when looking up a user name to import. For example, userPrincipalName or samAccountName",
+			},
+			"email": { // Email
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's email address. For example, mail",
+			},
+			"display_name": { // FullName
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's full name. For example, displayName",
+			},
+			"given_name": { // GivenName
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's given name. For example, givenName",
+			},
+			"surname": { // Surname
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's surname. For example, sn",
+			},
+			"telephone": { // Telephone
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's telephone number. For example, telephoneNumber",
+			},
+			"group_membership_identifier": { // GroupMembershipIdentifier
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute that identifies a user as a member of a group. For example, dn",
+			},
+			"group_back_link_identifier": { // GroupBackLinkIdentifier
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "LDAP attribute that returns the identifiers of all the groups of which the user is a member",
+			},
+		},
+	},
+}
+
+// resourceLdapGroupAttributes defines the elements of types.OrgLdapGroupAttributes
+// The field names are the ones used in the GUI, with a comment to indicate which API field each one corresponds to
+var resourceLdapGroupAttributes = &schema.Schema{
+	Type:        schema.TypeList,
+	Required:    true,
+	MaxItems:    1,
+	Description: "Group settings when `ldap_mode` is CUSTOM",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_class": { // ObjectClass
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP objectClass of which imported groups are members. For example, group",
+			},
+			"unique_identifier": { // ObjectIdentifier
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use as the unique identifier for a group. For example, objectGuid",
+			},
+			"name": { // GroupName
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the group name. For example, cn",
+			},
+			"membership": { // Membership
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use when getting the members of a group. For example, member",
+			},
+			"group_membership_identifier": { // MembershipIdentifier
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute that identifies a group as a member of another group. For example, dn",
+			},
+			"group_back_link_identifier": { // BackLinkIdentifier
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "LDAP group attribute used to identify a group member",
+			},
+		},
+	},
+}
+
+// resourceVcfaOrgLdap defines types.OrgLdapSettingsType
+// The field names are the ones used in the GUI, with a comment to indicate which API field each one corresponds to
+func resourceVcfaOrgLdap() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourceVcfaOrgLdapRead,
+		CreateContext: resourceVcfaOrgLdapCreate,
+		UpdateContext: resourceVcfaOrgLdapUpdate,
+		DeleteContext: resourceVcfaOrgLdapDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcfaOrgLdapImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"org_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Organization ID",
+			},
+			"ldap_mode": { // OrgLdapMode
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "Type of LDAP settings (one of NONE, SYSTEM, CUSTOM)",
+				ValidateFunc: validation.StringInSlice([]string{types.LdapModeNone, types.LdapModeSystem, types.LdapModeCustom}, false),
+			},
+			"custom_user_ou": { // CustomUsersOu
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "If ldap_mode is SYSTEM, specifies a LDAP attribute=value pair to use for OU (organizational unit)",
+			},
+			"custom_settings": { // CustomOrgLdapSettings
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Custom settings when `ldap_mode` is CUSTOM",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server": { // HostName
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "host name or IP of the LDAP server",
+						},
+						"port": { // Port
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "Port number for LDAP service",
+						},
+						"authentication_method": { // AuthenticationMechanism
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "authentication method: one of SIMPLE, MD5DIGEST, NTLM",
+							ValidateFunc: validation.StringInSlice([]string{"SIMPLE", "MD5DIGEST", "NTLM"}, false),
+						},
+						"connector_type": { // ConnectorType
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "type of connector: one of OPEN_LDAP, ACTIVE_DIRECTORY",
+							ValidateFunc: validation.StringInSlice([]string{"OPEN_LDAP", "ACTIVE_DIRECTORY"}, false),
+						},
+						"base_distinguished_name": { //SearchBase
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "LDAP search base",
+						},
+						"is_ssl": { // IsSsl
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "True if the LDAP service requires an SSL connection",
+						},
+						"username": { // Username
+							Type:     schema.TypeString,
+							Optional: true,
+							Description: `Username to use when logging in to LDAP, specified using LDAP attribute=value ` +
+								`pairs (for example: cn="ldap-admin", c="example", dc="com")`,
+						},
+						"password": { // Password
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+							Description: `Password for the user identified by UserName. This value is never returned by GET. ` +
+								`It is inspected on create and modify. ` +
+								`On modify, the absence of this element indicates that the password should not be changed`,
+						},
+						"user_attributes":  resourceLdapUserAttributes,  // CustomOrgLdapSettings.UserAttributes
+						"group_attributes": resourceLdapGroupAttributes, // CustomOrgLdapSettings.GroupAttributes
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceVcfaOrgLdapCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}, origin string) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	if !vcdClient.Client.IsSysAdmin {
+		return diag.Errorf("resource vcd_org_ldap requires System administrator privileges")
+	}
+	orgId := d.Get("org_id").(string)
+
+	adminOrg, err := vcdClient.GetAdminOrgById(orgId)
+	if err != nil {
+		return diag.Errorf("[Org LDAP %s] error searching for Org %s: %s", origin, orgId, err)
+	}
+
+	settings, err := fillLdapSettings(d)
+	if err != nil {
+		return diag.Errorf("[Org LDAP %s] error collecting settings values: %s", origin, err)
+	}
+
+	_, err = adminOrg.LdapConfigure(settings)
+	if err != nil {
+		return diag.Errorf("[Org LDAP %s] error setting org '%s' LDAP configuration: %s", origin, orgId, err)
+	}
+	return resourceVcfaOrgLdapRead(ctx, d, meta)
+}
+
+func resourceVcfaOrgLdapCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceVcfaOrgLdapCreateOrUpdate(ctx, d, meta, "create")
+}
+func resourceVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcfaOrgLdapRead(ctx, d, meta, "resource")
+}
+
+func genericVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}, origin string) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	if !vcdClient.Client.IsSysAdmin {
+		return diag.Errorf("resource vcd_org_ldap requires System administrator privileges")
+	}
+	orgId := d.Get("org_id").(string)
+
+	tmOrg, err := vcdClient.GetTmOrgById(orgId)
+	if govcd.IsNotFound(err) && origin == "resource" {
+		log.Printf("[INFO] unable to find Organization %s LDAP settings: %s. Removing from state", orgId, err)
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("unable to find organization %s: %s", orgId, err)
+	}
+
+	config, err := tmOrg.GetLdapConfiguration()
+	if err != nil {
+		d.SetId("")
+		return diag.Errorf("[Org LDAP read %s] error getting LDAP settings for Org %s: %s", origin, orgId, err)
+	}
+
+	dSet(d, "org_id", orgId)
+	dSet(d, "ldap_mode", config.OrgLdapMode)
+	dSet(d, "custom_user_ou", config.CustomUsersOu)
+	d.SetId(tmOrg.TmOrg.ID)
+
+	if config.OrgLdapMode == "CUSTOM" {
+		customSettings := map[string]interface{}{
+			"server":                  config.CustomOrgLdapSettings.HostName,
+			"port":                    config.CustomOrgLdapSettings.Port,
+			"authentication_method":   config.CustomOrgLdapSettings.AuthenticationMechanism,
+			"connector_type":          config.CustomOrgLdapSettings.ConnectorType,
+			"base_distinguished_name": config.CustomOrgLdapSettings.SearchBase,
+			"is_ssl":                  config.CustomOrgLdapSettings.IsSsl,
+			"username":                config.CustomOrgLdapSettings.Username,
+			// the password field is never returned by GET. Here we set it explicitly to be reminded of that fact
+			"password": "",
+			"user_attributes": []map[string]interface{}{
+				{
+					"object_class":                config.CustomOrgLdapSettings.UserAttributes.ObjectClass,
+					"unique_identifier":           config.CustomOrgLdapSettings.UserAttributes.ObjectIdentifier,
+					"username":                    config.CustomOrgLdapSettings.UserAttributes.Username,
+					"email":                       config.CustomOrgLdapSettings.UserAttributes.Email,
+					"display_name":                config.CustomOrgLdapSettings.UserAttributes.FullName,
+					"given_name":                  config.CustomOrgLdapSettings.UserAttributes.GivenName,
+					"surname":                     config.CustomOrgLdapSettings.UserAttributes.Surname,
+					"telephone":                   config.CustomOrgLdapSettings.UserAttributes.Telephone,
+					"group_membership_identifier": config.CustomOrgLdapSettings.UserAttributes.GroupMembershipIdentifier,
+					"group_back_link_identifier":  config.CustomOrgLdapSettings.UserAttributes.GroupBackLinkIdentifier,
+				},
+			},
+			"group_attributes": []map[string]interface{}{
+				{
+					"object_class":                config.CustomOrgLdapSettings.GroupAttributes.ObjectClass,
+					"unique_identifier":           config.CustomOrgLdapSettings.GroupAttributes.ObjectIdentifier,
+					"name":                        config.CustomOrgLdapSettings.GroupAttributes.GroupName,
+					"membership":                  config.CustomOrgLdapSettings.GroupAttributes.Membership,
+					"group_membership_identifier": config.CustomOrgLdapSettings.GroupAttributes.MembershipIdentifier,
+					"group_back_link_identifier":  config.CustomOrgLdapSettings.GroupAttributes.BackLinkIdentifier,
+				},
+			},
+		}
+		err = d.Set("custom_settings", []map[string]interface{}{customSettings})
+		if err != nil {
+			return diag.Errorf("[Org LDAP read %s] error setting 'user_attributes' field: %s", origin, err)
+		}
+	}
+	return nil
+}
+
+func resourceVcfaOrgLdapUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceVcfaOrgLdapCreateOrUpdate(ctx, d, meta, "update")
+}
+
+func resourceVcfaOrgLdapDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	if !vcdClient.Client.IsSysAdmin {
+		return diag.Errorf("resource vcd_org_ldap requires System administrator privileges")
+	}
+	orgId := d.Get("org_id").(string)
+
+	tmOrg, err := vcdClient.GetTmOrgById(orgId)
+	if err != nil {
+		return diag.Errorf("[Org LDAP delete] error searching for Org %s: %s", orgId, err)
+	}
+	return diag.FromErr(tmOrg.LdapDisable())
+}
+
+func fillLdapSettings(d *schema.ResourceData) (*types.OrgLdapSettingsType, error) {
+	settings := types.OrgLdapSettingsType{
+		OrgLdapMode: d.Get("ldap_mode").(string),
+	}
+
+	if settings.OrgLdapMode == "SYSTEM" {
+		settings.CustomUsersOu = d.Get("custom_user_ou").(string)
+		return &settings, nil
+	}
+
+	if settings.OrgLdapMode != "CUSTOM" {
+		return &settings, nil
+	}
+	customSettings := d.Get("custom_settings")
+	if customSettings == nil {
+		return nil, fmt.Errorf("custom_settings are empty with CUSTOM ldap_mode")
+	}
+	customSettingsList, ok := customSettings.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid custom settings: expected []interface{}")
+	}
+	customSettingsMap, ok := customSettingsList[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid custom settings: expected map[string]interface{}")
+	}
+
+	settings.CustomOrgLdapSettings = &types.CustomOrgLdapSettings{
+		HostName:                customSettingsMap["server"].(string),
+		Port:                    customSettingsMap["port"].(int),
+		IsSsl:                   customSettingsMap["is_ssl"].(bool),
+		SearchBase:              customSettingsMap["base_distinguished_name"].(string),
+		Username:                customSettingsMap["username"].(string),
+		Password:                customSettingsMap["password"].(string),
+		AuthenticationMechanism: customSettingsMap["authentication_method"].(string),
+		ConnectorType:           customSettingsMap["connector_type"].(string),
+	}
+
+	rawUserAttributesList, okUserList := customSettingsMap["user_attributes"].([]interface{})
+	rawGroupAttributesList, okGroupList := customSettingsMap["group_attributes"].([]interface{})
+	if !okUserList || len(rawUserAttributesList) == 0 {
+		return nil, fmt.Errorf("user_attributes settings are empty with CUSTOM ldap_mode")
+	}
+	if !okGroupList || len(rawGroupAttributesList) == 0 {
+		return nil, fmt.Errorf("group_attributes settings are empty with CUSTOM ldap_mode")
+	}
+	userAttributesMap, okUser := rawUserAttributesList[0].(map[string]interface{})
+	groupAttributesMap, okGroup := rawGroupAttributesList[0].(map[string]interface{})
+	if !okUser || userAttributesMap == nil || len(userAttributesMap) == 0 {
+		return nil, fmt.Errorf("user_attributes settings are empty with CUSTOM ldap_mode")
+	}
+	if !okGroup || groupAttributesMap == nil || len(groupAttributesMap) == 0 {
+		return nil, fmt.Errorf("group_attributes settings are empty with CUSTOM ldap_mode")
+	}
+	settings.CustomOrgLdapSettings.UserAttributes = &types.OrgLdapUserAttributes{
+		ObjectClass:               userAttributesMap["object_class"].(string),
+		ObjectIdentifier:          userAttributesMap["unique_identifier"].(string),
+		Username:                  userAttributesMap["username"].(string),
+		Email:                     userAttributesMap["email"].(string),
+		FullName:                  userAttributesMap["display_name"].(string),
+		GivenName:                 userAttributesMap["given_name"].(string),
+		Surname:                   userAttributesMap["surname"].(string),
+		Telephone:                 userAttributesMap["telephone"].(string),
+		GroupMembershipIdentifier: userAttributesMap["group_membership_identifier"].(string),
+		GroupBackLinkIdentifier:   userAttributesMap["group_back_link_identifier"].(string),
+	}
+	settings.CustomOrgLdapSettings.GroupAttributes = &types.OrgLdapGroupAttributes{
+		ObjectClass:          groupAttributesMap["object_class"].(string),
+		ObjectIdentifier:     groupAttributesMap["unique_identifier"].(string),
+		GroupName:            groupAttributesMap["name"].(string),
+		Membership:           groupAttributesMap["membership"].(string),
+		MembershipIdentifier: groupAttributesMap["group_membership_identifier"].(string),
+		BackLinkIdentifier:   groupAttributesMap["group_back_link_identifier"].(string),
+	}
+
+	return &settings, nil
+}
+
+// resourceVcfaOrgLdapImport is responsible for importing the resource.
+// The d.ID() field as being passed from `terraform import _resource_name_ _the_id_string_ requires
+// a name based dot-formatted path to the object to lookup the object and sets the id of object.
+// `terraform import` automatically performs `refresh` operation which loads up all other fields.
+// For this resource, the import path is just the org name (or Org ID).
+//
+// Example import path (id): orgName
+func resourceVcfaOrgLdapImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	orgName := d.Id()
+
+	vcdClient := meta.(*VCDClient)
+	tmOrg, err := vcdClient.GetTmOrgByName(orgName)
+	if err != nil {
+		return nil, err
+	}
+
+	dSet(d, "org_id", tmOrg.TmOrg.ID)
+
+	d.SetId(tmOrg.TmOrg.ID)
+	return []*schema.ResourceData{d}, nil
+}

--- a/website/docs/d/org_ldap.html.markdown
+++ b/website/docs/d/org_ldap.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "vcfa"
+page_title: "VMware Cloud Foundation Automation: vcfa_org_ldap"
+sidebar_current: "docs-vcfa-data-source-org-ldap"
+description: |-
+  Provides a data source to read LDAP configuration for an Organization.
+---
+
+# vcfa\_org\_ldap
+
+Provides a data source to read LDAP configuration for an Organization.
+
+## Example Usage
+
+```hcl
+data "vcfa_org" "my-org" {
+  name = "my-org"
+}
+
+data "vcfa_org_ldap" "first" {
+  org_id = data.vcfa_org.my-org.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org_id` - (Required)  - ID of the organization containing the LDAP settings
+
+## Attribute Reference
+
+All the arguments and attributes defined in
+[`vcfa_org_ldap`](/providers/vmware/vcfa/latest/docs/resources/org_ldap) resource are available.

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -16,19 +16,10 @@ This can be used to create, update, and delete LDAP configuration for an organiz
 ## Example Usage 1 - Custom configuration
 
 ```hcl
-provider "vcfa" {
-  user     = var.admin_user
-  password = var.admin_password
-  org      = "System"
-  url      = "https://AcmeVcfa/api"
-}
-
 data "vcfa_org" "my-org" {
   name = "my-org"
 }
 
-# The settings below (except the server IP) are taken from the LDAP docker testing image
-# https://github.com/rroemhild/docker-test-openldap
 resource "vcfa_org_ldap" "my-org-ldap" {
   org_id    = data.vcfa_org.my-org.id
   ldap_mode = "CUSTOM"
@@ -36,10 +27,10 @@ resource "vcfa_org_ldap" "my-org-ldap" {
     server                  = "192.168.1.172"
     port                    = 389
     is_ssl                  = false
-    username                = "cn=admin,dc=planetexpress,dc=com"
-    password                = "GoodNewsEveryone"
+    username                = "cn=admin,dc=foo,dc=com"
+    password                = "StrongPassword"
     authentication_method   = "SIMPLE"
-    base_distinguished_name = "dc=planetexpress,dc=com"
+    base_distinguished_name = "dc=foo,dc=com"
     connector_type          = "OPEN_LDAP"
     user_attributes {
       object_class                = "inetOrgPerson"

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -1,0 +1,179 @@
+---
+layout: "vcfa"
+page_title: "VMware Cloud Foundation Automation: vcfa_org_ldap"
+sidebar_current: "docs-vcfa-resource-org-ldap"
+description: |-
+  Provides a VMware Cloud Foundation Automation Organization LDAP resource. This can be used to create, delete, and update LDAP configuration for an organization .
+---
+
+# vcfa\_org\_ldap
+
+Provides a VMware Cloud Foundation Automation Organization LDAP resource.
+This can be used to create, update, and delete LDAP configuration for an organization.
+
+-> **Note:** This resource requires system administrator privileges.
+
+## Example Usage 1 - Custom configuration
+
+```hcl
+provider "vcfa" {
+  user     = var.admin_user
+  password = var.admin_password
+  org      = "System"
+  url      = "https://AcmeVcd/api"
+}
+
+data "vcfa_org" "my-org" {
+  name = "my-org"
+}
+
+# The settings below (except the server IP) are taken from the LDAP docker testing image
+# https://github.com/rroemhild/docker-test-openldap
+resource "vcfa_org_ldap" "my-org-ldap" {
+  org_id    = data.vcfa_org.my-org.id
+  ldap_mode = "CUSTOM"
+  custom_settings {
+    server                  = "192.168.1.172"
+    port                    = 389
+    is_ssl                  = false
+    username                = "cn=admin,dc=planetexpress,dc=com"
+    password                = "GoodNewsEveryone"
+    authentication_method   = "SIMPLE"
+    base_distinguished_name = "dc=planetexpress,dc=com"
+    connector_type          = "OPEN_LDAP"
+    user_attributes {
+      object_class                = "inetOrgPerson"
+      unique_identifier           = "uid"
+      display_name                = "cn"
+      username                    = "uid"
+      given_name                  = "givenName"
+      surname                     = "sn"
+      telephone                   = "telephoneNumber"
+      group_membership_identifier = "dn"
+      email                       = "mail"
+    }
+    group_attributes {
+      name                        = "cn"
+      object_class                = "group"
+      membership                  = "member"
+      unique_identifier           = "cn"
+      group_membership_identifier = "dn"
+    }
+  }
+}
+```
+
+-> **Note** 
+The password value never gets returned by GET. Therefore, if we want `terraform plan` to return a clean state, we need
+to add a `lifecycle` block at the end of the resource definition, after creating or updating it.
+And we need to remove the `lifecycle` block _if we want to change the password_.
+
+```hcl
+resource "vcfa_org_ldap" "my-org-ldap" {
+  # all other fields
+  # ...
+  lifecycle {
+    # password value does not get returned by GET
+    ignore_changes = [custom_settings[0].password]
+  }
+}
+```
+
+## Example Usage 2 - Using system configuration
+
+```hcl
+data "vcfa_org" "my-org" {
+  name = "my-org"
+}
+
+resource "vcfa_org_ldap" "my-org-ldap" {
+  org_id         = data.vcfa_org.my-org.id
+  ldap_mode      = "SYSTEM"
+  custom_user_ou = "ou=Foo,dc=domain,dc=local base DN"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org_id` - (Required) Org ID: there is only one LDAP configuration available for an organization. Thus, the resource can be identified by the Org.
+* `ldap_mode` - (Required) One of `NONE`, `CUSTOM`, `SYSTEM`. Note that using `NONE` has the effect of removing the LDAP settings
+* `custom_user_ou` - (Optional; *v3.11+*) If `ldap_mode` is `SYSTEM`, specifies an LDAP `attribute=value` pair to use for OU (organizational unit)
+* `custom_settings` - (Optional) LDAP server configuration. Becomes mandatory if `ldap_mode` is set to `CUSTOM`. See [Custom Settings](#custom-settings) below for details
+
+<a id="custom-settings"></a>
+## Custom Settings
+
+The `custom_settings` section contains the configuration for the LDAP server
+
+* `server` - (Required) The IP address or host name of the server providing the LDAP service
+* `port` - (Required) Port number of the LDAP server (usually 389 for LDAP, 636 for LDAPS)
+* `authentication_method` - (Required) Authentication method: one of `SIMPLE`, `MD5DIGEST`, `NTLM`
+* `connector_type` - (Required) Type of connector: one of `OPEN_LDAP`, `ACTIVE_DIRECTORY`
+* `base_distinguished_name` - (Required) LDAP search base
+* `is_ssl` - (Optional) True if the LDAP service requires an SSL connection
+* `username` - (Optional) _Username_ to use when logging in to LDAP, specified using LDAP attribute=value pairs 
+  (for example: cn="ldap-admin", c="example", dc="com")
+* `password` - (Optional) _Password_ for the user identified by UserName. This value is never returned by GET. 
+   It is inspected on create and modify. On modify, the absence of this element indicates that the password should not be changed
+
+* `user_attributes` - (Required) User settings when `ldap_mode` is `CUSTOM` See [User Attributes](#user-attributes) below for details
+* `group_attributes` - (Required) Group settings when `ldap_mode` is `CUSTOM` See [Group Attributes](#group-attributes) below for details
+
+<a id="user-attributes"></a>
+### User Attributes
+
+* `object_class` - (Required)  LDAP _objectClass_ of which imported users are members. For example, _user_ or _person_
+* `unique_identifier` - (Required) LDAP attribute to use as the unique identifier for a user. For example, _objectGuid_
+* `username` - (Required) LDAP attribute to use when looking up a username to import. For example, _userPrincipalName_ or _samAccountName_
+* `email` - (Required) LDAP attribute to use for the user's email address. For example, _mail_
+* `display_name` - (Required) LDAP attribute to use for the user's full name. For example, _displayName_
+* `given_name` - (Required) LDAP attribute to use for the user's given name. For example, _givenName_
+* `surname` - (Required) LDAP attribute to use for the user's surname. For example, _sn_
+* `telephone` - (Required) LDAP attribute to use for the user's telephone number. For example, _telephoneNumber_
+* `group_membership_identifier` - (Required) LDAP attribute that identifies a user as a member of a group. For example, _dn_
+* `group_back_link_identifier` - (Optional) LDAP attribute that returns the identifiers of all the groups of which the user is a member
+
+<a id="group-attributes"></a>
+### Group Attributes
+
+* `object_class` - (Required) LDAP _objectClass_ of which imported groups are members. For example, _group_
+* `unique_identifier` - (Required) LDAP attribute to use as the unique identifier for a group. For example, _objectGuid_
+* `name` - (Required) LDAP attribute to use for the group name. For example, _cn_
+* `membership` - (Required) LDAP attribute to use when getting the members of a group. For example, _member_
+* `group_membership_identifier` - (Required) LDAP attribute that identifies a group as a member of another group. For example, _dn_
+* `group_back_link_identifier` - (Optional) LDAP group attribute used to identify a group member
+
+## Importing
+
+~> **Note:** The current implementation of Terraform import can only import resources into the state. It does not generate
+configuration. [More information.][docs-import]
+
+An existing LDAP configuration for an Org can be [imported][docs-import] into this resource via supplying the path for an Org. Since the Org is
+at the top of the vCD hierarchy, the path corresponds to the Org name.
+For example, using this structure, representing an existing LDAP configuration that was **not** created using Terraform:
+
+```hcl
+data "vcfa_org" "my-org" {
+  name = "my-org"
+}
+
+resource "vcfa_org_ldap" "my-org-ldap" {
+  org_id = data.vcfa_org.my-org.id
+}
+```
+
+You can import such LDAP configuration into terraform state using one of the following commands
+
+```
+# EITHER
+terraform import vcfa_org_ldap.my-org-ldap organization_name
+# OR
+terraform import vcfa_org_ldap.my-org-ldap organization_id
+```
+
+After that, you must expand the configuration file before you can either update or delete the LDAP configuration. Running `terraform plan`
+at this stage will show the difference between the minimal configuration file and the stored properties.
+
+[docs-import]:https://www.terraform.io/docs/import/

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -20,7 +20,7 @@ provider "vcfa" {
   user     = var.admin_user
   password = var.admin_password
   org      = "System"
-  url      = "https://AcmeVcd/api"
+  url      = "https://AcmeVcfa/api"
 }
 
 data "vcfa_org" "my-org" {
@@ -147,11 +147,11 @@ The `custom_settings` section contains the configuration for the LDAP server
 
 ## Importing
 
-~> **Note:** The current implementation of Terraform import can only import resources into the state. It does not generate
-configuration. [More information.][docs-import]
+~> **Note:** The current implementation of Terraform import can only import resources into the
+state. It does not generate configuration. However, an experimental feature in Terraform 1.5+ allows
+also code generation. See [Importing resources][importing-resources] for more information.
 
-An existing LDAP configuration for an Org can be [imported][docs-import] into this resource via supplying the path for an Org. Since the Org is
-at the top of the vCD hierarchy, the path corresponds to the Org name.
+An existing LDAP configuration for an Organization can be [imported][docs-import] into this resource via supplying the path for an Organization name.
 For example, using this structure, representing an existing LDAP configuration that was **not** created using Terraform:
 
 ```hcl
@@ -167,10 +167,7 @@ resource "vcfa_org_ldap" "my-org-ldap" {
 You can import such LDAP configuration into terraform state using one of the following commands
 
 ```
-# EITHER
 terraform import vcfa_org_ldap.my-org-ldap organization_name
-# OR
-terraform import vcfa_org_ldap.my-org-ldap organization_id
 ```
 
 After that, you must expand the configuration file before you can either update or delete the LDAP configuration. Running `terraform plan`

--- a/website/vcfa.erb
+++ b/website/vcfa.erb
@@ -102,6 +102,9 @@
             <li<%= sidebar_current("docs-vcfa-data-source-certificate") %>>
               <a href="/docs/providers/vcfa/d/certificate.html">vcfa_certificate</a>
             </li>
+            <li<%= sidebar_current("docs-vcfa-data-source-org-ldap") %>>
+              <a href="/docs/providers/vcfa/d/org_ldap.html">vcfa_org_ldap</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcfa-resource") %>>
@@ -163,6 +166,9 @@
             </li>
             <li<%= sidebar_current("docs-vcfa-resource-certificate") %>>
               <a href="/docs/providers/vcfa/r/certificate.html">vcfa_certificate</a>
+            </li>
+            <li<%= sidebar_current("docs-vcfa-resource-org-ldap") %>>
+              <a href="/docs/providers/vcfa/r/org_ldap.html">vcfa_org_ldap</a>
             </li>
            </ul>
         </li>


### PR DESCRIPTION
This PR adds `vcfa_org_ldap` resource and data source.

To test it uses vCenter configured in the testing JSON configuration as LDAP server, so nothing special is needed.