### PR TITLE
Add VM classes and Storage policies to Org Region Quotas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,3 +66,5 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/vmware/go-vcloud-director/v3 => /Users/abarreiro/Documents/Development/go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,6 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.26 h1:nX+q6+X4VHzM+tiXr2N9NKK+Nu99660dM6lXezsu4uo=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.26/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/vcfa/datasource_vcfa_vm_class.go
+++ b/vcfa/datasource_vcfa_vm_class.go
@@ -1,0 +1,88 @@
+package vcfa
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v3/govcd"
+	"github.com/vmware/go-vcloud-director/v3/types/v56"
+)
+
+const labelVcfaRegionVmClass = "Region VM Class"
+
+func datasourceVcfaRegionVmClass() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcfaRegionVmClassRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: fmt.Sprintf("The name of the %s", labelVcfaRegionVmClass),
+			},
+			"region_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: fmt.Sprintf("The ID of the %s that owns the %s", labelVcfaRegion, labelVcfaRegionVmClass),
+			},
+			"cpu_reservation_mhz": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: fmt.Sprintf("CPU that a Virtual Machine reserves when this %s is applied", labelVcfaRegionVmClass),
+			},
+			"memory_reservation_mib": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: fmt.Sprintf("Memory in MiB that a Virtual Machine reserves when this %s is applied", labelVcfaRegionVmClass),
+			},
+			"cpu_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: fmt.Sprintf("Number of CPUs that a Virtual Machine gets when this %s is applied", labelVcfaRegionVmClass),
+			},
+			"memory_mib": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: fmt.Sprintf("Memory in MiB that a Virtual Machine gets when this %s is applied", labelVcfaRegionVmClass),
+			},
+			"reserved": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: fmt.Sprintf("Whether this %s can be used to reserve number of its instances within a namespace", labelVcfaRegionVmClass),
+			},
+		},
+	}
+}
+
+func datasourceVcfaRegionVmClassRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	tmClient := meta.(ClientContainer).tmClient
+	c := dsReadConfig[*govcd.RegionVirtualMachineClass, types.RegionVirtualMachineClass]{
+		entityLabel: labelVcfaRegionVmClass,
+		getEntityFunc: func(name string) (*govcd.RegionVirtualMachineClass, error) {
+			return tmClient.GetRegionVirtualMachineClassByNameAndRegionId(name, d.Get("region_id").(string))
+		},
+		stateStoreFunc: setVmClassData,
+	}
+	return readDatasource(ctx, d, meta, c)
+}
+
+func setVmClassData(_ *VCDClient, d *schema.ResourceData, o *govcd.RegionVirtualMachineClass) error {
+	if o == nil || o.RegionVirtualMachineClass == nil {
+		return fmt.Errorf("VM Class cannot be nil")
+	}
+	d.SetId(o.RegionVirtualMachineClass.ID)
+	dSet(d, "name", o.RegionVirtualMachineClass.Name)
+	region := ""
+	if o.RegionVirtualMachineClass.Region != nil {
+		region = o.RegionVirtualMachineClass.Region.ID
+	}
+	dSet(d, "region_id", region)
+	dSet(d, "cpu_reservation_mhz", o.RegionVirtualMachineClass.CpuReservationMHz)
+	dSet(d, "memory_reservation_mib", o.RegionVirtualMachineClass.MemoryReservationMiB)
+	dSet(d, "cpu_count", o.RegionVirtualMachineClass.CpuCount)
+	dSet(d, "memory_mib", o.RegionVirtualMachineClass.MemoryMiB)
+	dSet(d, "reserved", o.RegionVirtualMachineClass.Reserved)
+
+	return nil
+}

--- a/vcfa/provider.go
+++ b/vcfa/provider.go
@@ -42,6 +42,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcfa_ip_space":                        datasourceVcfaIpSpace(),                     // 1.0
 	"vcfa_region_zone":                     datasourceVcfaRegionZone(),                  // 1.0
 	"vcfa_org_vdc":                         datasourceVcfaOrgVdc(),                      // 1.0
+	"vcfa_region_vm_class":                 datasourceVcfaRegionVmClass(),               // 1.0
 	"vcfa_region_storage_policy":           datasourceVcfaRegionStoragePolicy(),         // 1.0
 	"vcfa_storage_class":                   datasourceVcfaStorageClass(),                // 1.0
 	"vcfa_content_library":                 datasourceVcfaContentLibrary(),              // 1.0

--- a/website/docs/d/region_vm_class.html.markdown
+++ b/website/docs/d/region_vm_class.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "vcfa"
+page_title: "VMware Cloud Foundation Automation: vcfa_region_vm_class"
+sidebar_current: "docs-vcfa-data-source-region-vm-class"
+description: |-
+  Provides a data source to read Region Virtual Machine Classes in VMware Cloud Foundation Automation
+---
+
+# vcfa\_region\_vm\_class
+
+Provides a data source to read Region Virtual Machine Classes in VMware Cloud Foundation Automation. These are useful
+when configuring an [Organization Region Quota](/providers/vmware/vcfa/latest/docs/resources/org_vdc) `region_vm_class_ids` argument.
+
+## Example Usage
+
+```hcl
+data "vcfa_region" "region1" {
+  name = "my-region"
+}
+
+data "vcfa_region_vm_class" "vm_class" {
+  name      = "best-effort-4xlarge"
+  region_id = data.vcfa_region.region1.id
+}
+
+data "vcfa_region_vm_class" "vm_class" {
+  name      = "best-effort-8xlarge"
+  region_id = data.vcfa_region.region1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` - (Required) The name of the Region VM Class
+- `region_id` - (Required)  An ID for the parent Region
+
+## Attribute Reference
+
+- `cpu_reservation_mhz` - CPU that a Virtual Machine reserves when this Region VM Class is applied
+- `memory_reservation_mib` - Memory in MiB that a Virtual Machine reserves when this Region VM Class is applied
+- `cpu_count` - Number of CPUs that a Virtual Machine gets when this Region VM Class is applied
+- `memory_mib` - Memory in MiB that a Virtual Machine gets when this Region VM Class is applied
+- `reserved` - Whether this Region VM Class can be used to reserve number of its instances within a namespace

--- a/website/vcfa.erb
+++ b/website/vcfa.erb
@@ -42,6 +42,9 @@
             <li<%= sidebar_current("docs-vcfa-data-source-region-zone") %>>
               <a href="/docs/providers/vcfa/d/region_zone.html">vcfa_region_zone</a>
             </li>
+            <li<%= sidebar_current("docs-vcfa-data-source-region-vm-class") %>>
+              <a href="/docs/providers/vcfa/d/region_vm_class.html">vcfa_region_vm_class</a>
+            </li>
             <li<%= sidebar_current("docs-vcfa-data-source-supervisor") %>>
               <a href="/docs/providers/vcfa/d/supervisor.html">vcfa_supervisor</a>
             </li>


### PR DESCRIPTION
This PR:

- Adds a new data source `vcfa_region_vm_class` to fetch VM Classes from an existing Region.
- Adds a new `Set` argument to `vcfa_org_vdc` named `region_vm_class_ids` that allows to assign VM classes (fetched with data source above) to the Region Quota