### PR TITLE
Remove network_provider_scope field from TestAccVcfaNsxManager

### DIFF
--- a/.changes/v1.0.0/4-features.md
+++ b/.changes/v1.0.0/4-features.md
@@ -1,4 +1,4 @@
 - **New Resource:** `vcfa_nsx_manager` to manage VMware Cloud Foundation Automation NSX Managers
-  [GH-4]
+  [GH-4, GH-33]
 - **New Data Source:** `vcfa_nsx_manager` to read VMware Cloud Foundation Automation NSX Managers
-  [GH-4]
+  [GH-4, GH-33]

--- a/vcfa/resource_vcfa_nsx_manager_test.go
+++ b/vcfa/resource_vcfa_nsx_manager_test.go
@@ -90,7 +90,6 @@ resource "vcfa_nsx_manager" "test" {
   username               = "{{.Username}}"
   password               = "{{.Password}}"
   url                    = "{{.Url}}"
-  network_provider_scope = ""
   auto_trust_certificate = true
 }
 `


### PR DESCRIPTION
This PR removes reference to`network_provider_scope` field from TestAccVcfaNsxManager.
The field is no longer available.
Test passes