### PR TITLE
Remove deprecated field in TestAccVcfaRegion test

### DIFF
--- a/vcfa/resource_vcfa_region_test.go
+++ b/vcfa/resource_vcfa_region_test.go
@@ -140,7 +140,6 @@ resource "vcfa_nsx_manager" "test" {
   username               = "{{.NsxManagerUsername}}"
   password               = "{{.NsxManagerPassword}}"
   url                    = "{{.NsxManagerUrl}}"
-  network_provider_scope = ""
   auto_trust_certificate = true
 }
 


### PR DESCRIPTION
Remove deprecated field `network_provider_scope` in TestAccVcfaRegion test for NSX manager creation .
Related to https://github.com/vmware/terraform-provider-vcfa/pull/33
