### PR TITLE
vcfa_vcenter -  refresh_vcenter_on_create, refresh_policies_on_create

### DIFF
--- a/.changes/v1.0.0/2-feature.md
+++ b/.changes/v1.0.0/2-feature.md
@@ -1,4 +1,4 @@
 * **New Resource:** `vcfa_vcenter` to manage VMware Cloud Foundation Automation
-  vCenter servers [GH-2]
+  vCenter servers [GH-2, GH-36]
 * **New Data Source:** `vcfa_vcenter` to read VMware Cloud Foundation Automation
   vCenter servers [GH-2]

--- a/vcfa/resource_generic_crud.go
+++ b/vcfa/resource_generic_crud.go
@@ -131,7 +131,7 @@ func createResource[O updateDeleter[O, I], I any](ctx context.Context, d *schema
 
 	err = execEntityHook(createdEntity, c.postCreateHooks)
 	if err != nil {
-		return diag.Errorf("error executing read %s hooks: %s", c.entityLabel, err)
+		return diag.Errorf("error executing post-create %s hooks: %s", c.entityLabel, err)
 	}
 
 	err = c.stateStoreFunc(tmClient, d, createdEntity)

--- a/vcfa/resource_generic_crud.go
+++ b/vcfa/resource_generic_crud.go
@@ -43,6 +43,9 @@ type crudConfig[O updateDeleter[O, I], I any] struct {
 	// preCreateHooks will be executed before the entity is created
 	preCreateHooks []schemaHook
 
+	// postCreateHooks that will be executed after the entity is created, but before it is stored in state
+	postCreateHooks []outerEntityHook[O]
+
 	// preUpdateHooks will be executed before submitting the data for update
 	preUpdateHooks []outerEntityHookInnerEntityType[O, *I]
 
@@ -124,6 +127,11 @@ func createResource[O updateDeleter[O, I], I any](ctx context.Context, d *schema
 		if err != nil {
 			return diag.Errorf("error creating %s: %s", c.entityLabel, err)
 		}
+	}
+
+	err = execEntityHook(createdEntity, c.postCreateHooks)
+	if err != nil {
+		return diag.Errorf("error executing read %s hooks: %s", c.entityLabel, err)
 	}
 
 	err = c.stateStoreFunc(tmClient, d, createdEntity)

--- a/vcfa/resource_vcfa_vcenter_test.go
+++ b/vcfa/resource_vcfa_vcenter_test.go
@@ -105,7 +105,7 @@ func TestAccVcfaVcenter(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateId:           params["Testname"].(string),
-				ImportStateVerifyIgnore: []string{"password", "auto_trust_certificate", "refresh_vcenter_on_read", "refresh_policies_on_read"},
+				ImportStateVerifyIgnore: []string{"password", "auto_trust_certificate", "refresh_vcenter_on_read", "refresh_policies_on_read", "refresh_vcenter_on_create", "refresh_policies_on_create"},
 			},
 			{
 				Config: configText4,

--- a/vcfa/vcfa_common_test.go
+++ b/vcfa/vcfa_common_test.go
@@ -34,14 +34,14 @@ data "vcfa_vcenter" "vc" {
 	}
 	return `
 resource "vcfa_vcenter" "vc" {
-  name                     = "` + t.Name() + `"
-  url                      = "` + testConfig.Tm.VcenterUrl + `"
-  auto_trust_certificate   = true
-  refresh_vcenter_on_read  = true
-  refresh_policies_on_read = false
-  username                 = "` + testConfig.Tm.VcenterUsername + `"
-  password                 = "` + testConfig.Tm.VcenterPassword + `"
-  is_enabled               = true
+  name                       = "` + t.Name() + `"
+  url                        = "` + testConfig.Tm.VcenterUrl + `"
+  auto_trust_certificate     = true
+  refresh_vcenter_on_create  = true
+  refresh_policies_on_create = false
+  username                   = "` + testConfig.Tm.VcenterUsername + `"
+  password                   = "` + testConfig.Tm.VcenterPassword + `"
+  is_enabled                 = true
 }
 `, "vcfa_vcenter.vc"
 }

--- a/vcfa/vcfa_common_test.go
+++ b/vcfa/vcfa_common_test.go
@@ -38,7 +38,7 @@ resource "vcfa_vcenter" "vc" {
   url                        = "` + testConfig.Tm.VcenterUrl + `"
   auto_trust_certificate     = true
   refresh_vcenter_on_create  = true
-  refresh_policies_on_create = false
+  refresh_policies_on_create = true
   username                   = "` + testConfig.Tm.VcenterUsername + `"
   password                   = "` + testConfig.Tm.VcenterPassword + `"
   is_enabled                 = true

--- a/website/docs/r/vcenter.html.markdown
+++ b/website/docs/r/vcenter.html.markdown
@@ -34,6 +34,16 @@ The following arguments are supported:
 * `description` - (Optional) An optional description for vCenter server
 * `username` - (Required) A username for authenticating to vCenter server
 * `password` - (Required) A password for authenticating to vCenter server
+* `refresh_vcenter_on_create` - (Optional) An optional flag to trigger refresh operation on the
+  underlying vCenter once after creation. This might take some time, but can help to load up new
+  artifacts from vCenter (e.g. Supervisors). This operation is visible as a new task in UI. Update
+  is a no-op. It may be useful after adding vCenter or if new infrastructure is added to vCenter.
+  Default `false`.
+* `refresh_policies_on_create` - (Optional) An optional flag to trigger policy refresh operation on
+  the underlying vCenter once after creation. This might take some time, but can help to load up new
+  artifacts from vCenter (e.g. Storage Policies). Update is a no-op. This operation is visible as a
+  new task in UI. It may be useful after adding vCenter or if new infrastructure is added to
+  vCenter. Default `false`. 
 * `refresh_vcenter_on_read` - (Optional) An optional flag to trigger refresh operation on the
   underlying vCenter on every read. This might take some time, but can help to load up new artifacts
   from vCenter (e.g. Supervisors). This operation is visible as a new task in UI. Update is a no-op.


### PR DESCRIPTION
Add options `refresh_vcenter_on_create`, `refresh_policies_on_create` to `vcfa_vcenter` in addition to already existing `refresh_policies_on_read` and `refresh_vcenter_on_read`.

Refreshing on every `read` operation (refresh, plan, apply) might be suboptimal due to time it might take sometimes, therefore `refresh_vcenter_on_create`, `refresh_policies_on_create` can be useful to ensure refresh is done once on creation to avoid Terraform failing on some missing storage policy.

### Testing