### PR TITLE
Bump SDK with Task workaround removal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
-	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.27
+	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.28
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.27 h1:b7yWY0nHhz4v07cAd4grkS78v8wTkNvg0FBsXADA6nI=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.27/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.28 h1:t0MXtWd0bzSkcK/5k+F0wo4EktgzbatLQx8P0ol4N94=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.28/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
Bumps SDK which contains https://github.com/vmware/go-vcloud-director/pull/754, as it should not be needed anymore:

https://github.com/vmware/go-vcloud-director/releases/tag/v3.0.0-alpha.28