### PR TITLE
Use unique IP Space scopes in tests

### DIFF
--- a/.changes/v1.0.0/8-features.md
+++ b/.changes/v1.0.0/8-features.md
@@ -1,2 +1,2 @@
-* **New Resource:** `vcfa_ip_space` to manage IP Spaces [GH-8]
+* **New Resource:** `vcfa_ip_space` to manage IP Spaces [GH-8, GH-39]
 * **New Data Source:** `vcfa_ip_space` to read IP Spaces [GH-8]

--- a/vcfa/vcfa_common_test.go
+++ b/vcfa/vcfa_common_test.go
@@ -191,7 +191,6 @@ resource "vcfa_ip_space" "test-` + nameSuffix + `" {
   default_quota_max_cidr_count  = 1
   default_quota_max_ip_count    = 1
   internal_scope {
-    name = "scope3"
     cidr = "32.0.` + octet3 + `.0/24"
   }
 }


### PR DESCRIPTION
This PR creates unique IP Space scope names by hashing destination VCFA instance url and taking first 6 chars of it.
It may not be 100% unique, but should avoid problems with testing.