### PR TITLE
Test tenant Content Libraries

### DIFF
--- a/.changes/v1.0.0/12-features.md
+++ b/.changes/v1.0.0/12-features.md
@@ -1,4 +1,4 @@
-- **New Resource:** `vcfa_content_library` to manage Content Libraries [GH-12]
-- **New Data Source:** `vcfa_content_library` to read Content Libraries [GH-12]
+- **New Resource:** `vcfa_content_library` to manage Content Libraries [GH-12, GH-42]
+- **New Data Source:** `vcfa_content_library` to read Content Libraries [GH-12, GH-42]
 - **New Data Source:** `vcfa_region_storage_policy` to read Region Storage Policies [GH-12]
 - **New Data Source:** `vcfa_storage_class` to read Storage Classes [GH-12]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
-	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.29
+	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.30
 )
 
 require (
@@ -66,5 +66,3 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v3 => github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250219114347-3c7cc94eb1f3

--- a/go.mod
+++ b/go.mod
@@ -66,3 +66,5 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/vmware/go-vcloud-director/v3 => github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250218120852-c95db0f2d9c3

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250218120852-c95db0f2d9c3 h1:sOaMlNQNH1n3NzswueZ5VerYVbyR352JVy26XWvAGJQ=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250218120852-c95db0f2d9c3/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -149,8 +151,6 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.28 h1:t0MXtWd0bzSkcK/5k+F0wo4EktgzbatLQx8P0ol4N94=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.28/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250219114347-3c7cc94eb1f3 h1:2szE9XjAyvvlowxXGmDn//Gg3EZV4hEGC1rXFERDJ2g=
-github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250219114347-3c7cc94eb1f3/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -151,6 +149,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.30 h1:CLa/a7hX92mfkvGgtPaZ9Jz7wanXiy5j/19BuBdMfuU=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.30/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/vcfa/provider_test.go
+++ b/vcfa/provider_test.go
@@ -108,6 +108,8 @@ func createSystemTemporaryVCFAConnection() *VCDClient {
 	return conn
 }
 
+// testOrgProvider configures a VCFA Terraform Provider with the credentials of a tenant (Organization) user, to login
+// as a tenant in VCFA.
 func testOrgProvider(orgName, username, password string) *schema.Provider {
 	newProvider := Provider()
 	newProvider.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {

--- a/vcfa/remove_leftovers_test.go
+++ b/vcfa/remove_leftovers_test.go
@@ -123,12 +123,12 @@ func removeLeftovers(tmClient *govcd.VCDClient, verbose bool) error {
 	}
 
 	// --------------------------------------------------------------
-	// Content Libraries
+	// Provider Content Libraries
 	// --------------------------------------------------------------
 	if tmClient.Client.IsSysAdmin {
 		cls, err := tmClient.GetAllContentLibraries(nil, nil)
 		if err != nil {
-			return fmt.Errorf("error retrieving Content Libraries: %s", err)
+			return fmt.Errorf("error retrieving Provider Content Libraries: %s", err)
 		}
 		for _, cl := range cls {
 			toBeDeleted := shouldDeleteEntity(alsoDelete, doNotDelete, cl.ContentLibrary.Name, "vcfa_content_library", 0, verbose)

--- a/vcfa/remove_leftovers_test.go
+++ b/vcfa/remove_leftovers_test.go
@@ -203,6 +203,30 @@ func removeLeftovers(tmClient *govcd.VCDClient, verbose bool) error {
 	}
 
 	// --------------------------------------------------------------
+	// Organizations
+	// --------------------------------------------------------------
+	if tmClient.Client.IsSysAdmin {
+		orgs, err := tmClient.GetAllTmOrgs(nil)
+		if err != nil {
+			return fmt.Errorf("error retrieving Organizations: %s", err)
+		}
+		for _, org := range orgs {
+			toBeDeleted := shouldDeleteEntity(alsoDelete, doNotDelete, org.TmOrg.Name, "vcfa_org", 0, verbose)
+			if toBeDeleted {
+				fmt.Printf("\t REMOVING Organization %s\n", org.TmOrg.Name)
+				err = org.Disable()
+				if err != nil {
+					return fmt.Errorf("error disabling %s '%s': %s", labelVcfaOrg, org.TmOrg.Name, err)
+				}
+				err := org.Delete()
+				if err != nil {
+					return fmt.Errorf("error deleting %s '%s': %s", labelVcfaOrg, org.TmOrg.Name, err)
+				}
+			}
+		}
+	}
+
+	// --------------------------------------------------------------
 	// NSX Managers
 	// --------------------------------------------------------------
 	if tmClient.Client.IsSysAdmin {
@@ -241,30 +265,6 @@ func removeLeftovers(tmClient *govcd.VCDClient, verbose bool) error {
 				err := vc.Delete()
 				if err != nil {
 					return fmt.Errorf("error deleting %s '%s': %s", labelVcfaVirtualCenter, vc.VSphereVCenter.Name, err)
-				}
-			}
-		}
-	}
-
-	// --------------------------------------------------------------
-	// Organizations
-	// --------------------------------------------------------------
-	if tmClient.Client.IsSysAdmin {
-		orgs, err := tmClient.GetAllTmOrgs(nil)
-		if err != nil {
-			return fmt.Errorf("error retrieving Organizations: %s", err)
-		}
-		for _, org := range orgs {
-			toBeDeleted := shouldDeleteEntity(alsoDelete, doNotDelete, org.TmOrg.Name, "vcfa_org", 0, verbose)
-			if toBeDeleted {
-				fmt.Printf("\t REMOVING Organization %s\n", org.TmOrg.Name)
-				err = org.Disable()
-				if err != nil {
-					return fmt.Errorf("error disabling %s '%s': %s", labelVcfaOrg, org.TmOrg.Name, err)
-				}
-				err := org.Delete()
-				if err != nil {
-					return fmt.Errorf("error deleting %s '%s': %s", labelVcfaOrg, org.TmOrg.Name, err)
 				}
 			}
 		}

--- a/vcfa/resource_vcfa_content_library.go
+++ b/vcfa/resource_vcfa_content_library.go
@@ -39,7 +39,7 @@ func resourceVcfaContentLibrary() *schema.Resource {
 			"delete_force": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: fmt.Sprintf("On deletion, forcefully deletes the %s and its %ss", labelVcfaContentLibrary, labelVcfaContentLibraryItem),
+				Description: fmt.Sprintf("On deletion, forcefully deletes the %s and its %ss. Only for PROVIDER Content Libraries", labelVcfaContentLibrary, labelVcfaContentLibraryItem),
 			},
 			"delete_recursive": {
 				Type:        schema.TypeBool,
@@ -202,7 +202,12 @@ func resourceVcfaContentLibraryDelete(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	cl.Delete(d.Get("delete_force").(bool), d.Get("delete_recursive").(bool))
+
+	deleteForce := d.Get("delete_force").(bool)
+	if cl.ContentLibrary.LibraryType != "PROVIDER" {
+		deleteForce = false // Forcefully deletion is not available for non-PROVIDER Content Libraries
+	}
+	err = cl.Delete(deleteForce, d.Get("delete_recursive").(bool))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -324,22 +324,30 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 
 const testAccVcfaContentLibraryTenantPrerequisites = `
 resource "vcfa_org" "test" {
+provider   = vcfa
+
   name         = "{{.Org}}"
   display_name = "{{.Org}}"
   description  = "{{.Org}}"
 }
 
 data "vcfa_role" "org-admin" {
+provider   = vcfa
+
   org_id = vcfa_org.test.id
   name   = "Organization Administrator"
 }
 
 data "vcfa_role" "org-user" {
+provider   = vcfa
+
   org_id = vcfa_org.test.id
   name   = "Organization User"
 }
 
 resource "vcfa_org_local_user" "user" {
+provider   = vcfa
+
   org_id   = vcfa_org.test.id
   role_ids = [data.vcfa_role.org-admin.id, data.vcfa_role.org-user.id]
   username = "test-user"
@@ -347,22 +355,29 @@ resource "vcfa_org_local_user" "user" {
 }
 
 data "vcfa_supervisor" "test" {
+  provider   = vcfa
   name       = "{{.SupervisorName}}"
   vcenter_id = {{.VcenterRef}}.id
   depends_on = [{{.VcenterRef}}]
 }
 
 data "vcfa_region_zone" "test" {
+provider   = vcfa
+
   region_id = {{.RegionId}}
   name      = "{{.SupervisorZoneName}}"
 }
 
 data "vcfa_region_storage_policy" "sp" {
+provider   = vcfa
+
   name      = "{{.StorageClass}}"
   region_id = {{.RegionId}}
 }
 
 resource "vcfa_org_region_quota" "test" {
+provider   = vcfa
+
   org_id         = vcfa_org.test.id
   region_id      = {{.RegionId}}
   supervisor_ids = [data.vcfa_supervisor.test.id]
@@ -383,6 +398,8 @@ resource "vcfa_org_region_quota" "test" {
 }
 
 data "vcfa_storage_class" "sc" {
+provider   = vcfa
+
   region_id = {{.RegionId}}
   name      = data.vcfa_region_storage_policy.sp.name
 }
@@ -390,6 +407,8 @@ data "vcfa_storage_class" "sc" {
 
 const testAccVcfaContentLibraryTenantStep1 = testAccVcfaContentLibraryTenantPrerequisites + `
 resource "vcfa_content_library" "cl1" {
+provider   = vcfa
+
   org_id      = vcfa_org.test.id
   name        = "{{.Name}}"
   description = "{{.Name}}"
@@ -403,6 +422,8 @@ resource "vcfa_content_library" "cl1" {
 }
 
 resource "vcfa_content_library" "cl2" {
+provider   = vcfa
+
   org_id      = vcfa_org.test.id
   name        = "{{.Name2}}"
   description = "{{.Name2}}"
@@ -424,8 +445,8 @@ provider "vcfa" {
   user                 = "test-user"
   password             = "long-change-ME1"
   url                  = "{{.VcfaUrl}}"
-  sysorg               = vcfa_org.test.name
-  org                  = vcfa_org.test.name
+  sysorg               = "{{.Org}}"
+  org                  = "{{.Org}}"
   allow_unverified_ssl = "true"
 }
 
@@ -450,16 +471,19 @@ resource "vcfa_content_library" "cl3" {
 
 const testAccVcfaContentLibraryTenantStep4 = testAccVcfaContentLibraryTenantStep3 + `
 data "vcfa_content_library" "cl_ds1" {
+provider   = vcfa
   org_id = vcfa_org.test.id
   name   = vcfa_content_library.cl1.name
 }
 
 data "vcfa_content_library" "cl_ds2" {
+provider   = vcfa
   org_id = vcfa_org.test.id
   name   = vcfa_content_library.cl2.name
 }
 
 data "vcfa_content_library" "cl_ds3" {
+provider   = vcfa
   org_id = vcfa_org.test.id
   name   = vcfa_content_library.cl3.name
 }

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -211,6 +211,7 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 	debugPrintf("#[DEBUG] CONFIGURATION step1: %s\n", configText1)
 	debugPrintf("#[DEBUG] CONFIGURATION step2: %s\n", configText2)
 	debugPrintf("#[DEBUG] CONFIGURATION step3: %s\n", configText3)
+	debugPrintf("#[DEBUG] CONFIGURATION step4: %s\n", configText4)
 	if vcfaShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -450,7 +450,7 @@ const testAccVcfaContentLibraryTenantStep3 = testAccVcfaContentLibraryTenantStep
 
 data "vcfa_storage_class" "sc-tenant" {
   provider  = vcfatenant
-  region_id = data.vcfa_region.region.id
+  region_id = {{.RegionId}}
   name      = data.vcfa_region_storage_policy.sp.name
 }
 

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -428,7 +428,6 @@ resource "vcfa_content_library" "cl1" {
   storage_class_ids = [
     data.vcfa_storage_class.sc.id
   ]
-  delete_force = true
   delete_recursive = true
 }
 
@@ -441,7 +440,7 @@ resource "vcfa_content_library" "cl2" {
   storage_class_ids = [
     data.vcfa_storage_class.sc.id
   ]
-  delete_force = true
+  delete_force     = true # Should be ignored, otherwise it would fail
   delete_recursive = true
 }
 `
@@ -456,20 +455,22 @@ data "vcfa_storage_class" "sc-tenant" {
 }
 
 resource "vcfa_content_library" "cl3" {
-  provider = vcfatenant
-
-  # Explicit dependency on Region Quota.
-  # A real tenant user should not need to do something like this (a Region Quota should be already provisioned),
-  # but as we created the Region Quota at same time, we need to guarantee dependencies
-  # so they are removed correctly afterwards.
-  org_id      = vcfa_org_region_quota.test.org_id
+  provider    = vcfatenant
+  org_id      = vcfa_org.test.id
   name        = "{{.Name3}}"
   description = "{{.Name3}}"
   storage_class_ids = [
     data.vcfa_storage_class.sc-tenant.id
   ]
-  delete_force = true
+  delete_force     = true # Should be ignored, otherwise it would fail
   delete_recursive = true
+
+  # Explicit dependency on Region Quota.
+  # A real tenant user should not need to do something like this (a Region Quota should be already provisioned),
+  # but as we created the Region Quota at same time, we need to guarantee dependencies
+  # so they are removed correctly afterwards.
+  # Also depends on the logged in user.
+  depends_on = [vcfa_org_region_quota.test, vcfa_org_local_user.user]
 }
 `
 

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -68,12 +68,12 @@ func TestAccVcfaContentLibraryProvider(t *testing.T) {
 			},
 			{
 				Config: configText1,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					// Region Storage Policy
 					resource.TestCheckResourceAttr(dsRegionStoragePolicy, "name", testConfig.Tm.StorageClass),
 					resource.TestCheckResourceAttrPair(dsRegionStoragePolicy, "region_id", regionHclRef, "id"),
 					resource.TestMatchResourceAttr(dsRegionStoragePolicy, "description", regexp.MustCompile(`.*`)),
-					resource.TestCheckResourceAttr(dsRegionStoragePolicy, "status", ""),
+					resource.TestCheckResourceAttr(dsRegionStoragePolicy, "status", "READY"),
 					resource.TestCheckResourceAttrSet(dsRegionStoragePolicy, "storage_capacity_mb"),
 					resource.TestCheckResourceAttrSet(dsRegionStoragePolicy, "storage_consumed_mb"),
 
@@ -101,14 +101,14 @@ func TestAccVcfaContentLibraryProvider(t *testing.T) {
 			},
 			{
 				Config: configText2,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					cachedId.testCheckCachedResourceFieldValue(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", t.Name()+"Updated"),
 				),
 			},
 			{
 				Config: configText3,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual(resourceName, "data.vcfa_content_library.cl_ds", []string{
 						"%", // Does not have delete_recursive, delete_force
 						"delete_recursive",

--- a/vcfa/resource_vcfa_org_region_quota_test.go
+++ b/vcfa/resource_vcfa_org_region_quota_test.go
@@ -27,7 +27,6 @@ func TestAccVcfaOrgRegionQuota(t *testing.T) {
 		"RegionId":           fmt.Sprintf("%s.id", regionHclRef),
 		"RegionVmClassRefs":  strings.Join(vmClassesRefs, ".id,\n    ") + ".id",
 		"StorageClass":       testConfig.Tm.StorageClass,
-		"StorageLimitMib":    "100",
 		"Tags":               "tm org regionQuota",
 	}
 	testParamsNotEmpty(t, params)

--- a/website/docs/d/content_library.html.markdown
+++ b/website/docs/d/content_library.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a VMware Cloud Foundation Automation Content Library data source. This can be used to read Content Libraries.
 
-## Example Usage
+## Example Usage for Provider libraries
 
 ```hcl
 data "vcfa_content_library" "cl" {
@@ -22,6 +22,23 @@ output "is_shared" {
 }
 output "owner_org" {
   value = data.vcfa_content_library.cl.org_id
+}
+```
+
+## Example Usage for Tenant libraries
+
+```hcl
+data "vcfa_org" "my-org" {
+  name = "my-org"
+}
+
+data "vcfa_content_library" "cl" {
+  org_id = data.vcfa_org.my-org.id
+  name   = "My Library"
+}
+
+output "is_shared" {
+  value = data.vcfa_content_library.cl.is_shared
 }
 ```
 

--- a/website/docs/r/content_library.html.markdown
+++ b/website/docs/r/content_library.html.markdown
@@ -107,7 +107,6 @@ resource "vcfa_content_library" "cl1" {
   storage_class_ids = [
     data.vcfa_storage_class.sc.id
   ]
-  delete_force = true
   delete_recursive = true
 
   # We need an available Region Quota
@@ -115,7 +114,7 @@ resource "vcfa_content_library" "cl1" {
 }
 ```
 
-## Example Usage for a Tenant Content Library as an Tenant User
+## Example Usage for a Tenant Content Library as a Tenant User
 
 ```hcl
 data "vcfa_region" "region" {
@@ -135,7 +134,6 @@ resource "vcfa_content_library" "cl1" {
   storage_class_ids = [
     data.vcfa_storage_class.sc.id
   ]
-  delete_force = true
   delete_recursive = true
 }
 ```
@@ -147,7 +145,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the Content Library
 * `org_id` - (Optional) The reference to the Organization that the Content Library belongs to. If it is not set, assumes the
   Content Library is of type `PROVIDER`
-* `delete_force` - (Optional) Defaults to `false`. On deletion, forcefully deletes the Content Library and its Content Library items
+* `delete_force` - (Optional) Defaults to `false`. On deletion, forcefully deletes the Content Library and its Content Library items. Only considered with
+  `PROVIDER` Content Libraries, ignored otherwise.
 * `delete_recursive` - (Optional) Defaults to `false`. On deletion, deletes the Content Library, including its Content Library items, in a single operation
 * `storage_class_ids` - (Required) A set of [Storage Class IDs](/providers/vmware/vcfa/latest/docs/data-sources/storage_class) used by this Content Library
 * `auto_attach` - (Optional) Defaults to `true`. For Tenant Content Libraries this field represents whether this Content Library should be

--- a/website/docs/r/content_library.html.markdown
+++ b/website/docs/r/content_library.html.markdown
@@ -110,7 +110,7 @@ resource "vcfa_content_library" "cl1" {
   delete_recursive = true
 
   # We need an available Region Quota
-  depends_on = [ vcfa_org_region_quota.test]
+  depends_on = [vcfa_org_region_quota.test]
 }
 ```
 


### PR DESCRIPTION
This PR adds a test for Tenant Content Libraries.

Tenant Content libraries need the `org_id` argument, when this is set, the Content Library will belong to an Organization.
The test creates a few libraries in a created Organization, and also logins as a tenant user to create a Content Library in this Organization.

The added test caught a bug in CL deletion (the error was being ignored). This PR also fixes that and updates documentation on this regard.