### PR TITLE
Tests: Do not cleanup classic org Content Libraries

### DIFF
--- a/.changes/v1.0.0/12-features.md
+++ b/.changes/v1.0.0/12-features.md
@@ -1,4 +1,4 @@
-- **New Resource:** `vcfa_content_library` to manage Content Libraries [GH-12, GH-42]
+- **New Resource:** `vcfa_content_library` to manage Content Libraries [GH-12, GH-42, GH-43]
 - **New Data Source:** `vcfa_content_library` to read Content Libraries [GH-12, GH-42]
 - **New Data Source:** `vcfa_region_storage_policy` to read Region Storage Policies [GH-12]
 - **New Data Source:** `vcfa_storage_class` to read Storage Classes [GH-12]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
-	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.30
+	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.31
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.30 h1:CLa/a7hX92mfkvGgtPaZ9Jz7wanXiy5j/19BuBdMfuU=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.30/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.31 h1:6v/eaVEhLO2kIqj3e5mtL97dsSMeFB1AApMtukJNb/4=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.31/go.mod h1:68KHsVns52dsq/w5JQYzauaU/+NAi1FmCxhBrFc/VoQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/vcfa/remove_leftovers_test.go
+++ b/vcfa/remove_leftovers_test.go
@@ -68,6 +68,9 @@ func removeLeftovers(tmClient *govcd.VCDClient, verbose bool) error {
 			return fmt.Errorf("error retrieving Organizations: %s", err)
 		}
 		for _, org := range orgs {
+			if org.TmOrg.IsClassicTenant {
+				continue
+			}
 			// --------------------------------------------------------------
 			// Tenant Content Libraries
 			// --------------------------------------------------------------


### PR DESCRIPTION
This PR:
* Bumps SDK
* Prevents Content Library cleanup for classic orgs