### PR TITLE
vcfa_vcenter requires nsx_manager_id

### DIFF
--- a/.changes/v1.0.0/2-feature.md
+++ b/.changes/v1.0.0/2-feature.md
@@ -1,4 +1,4 @@
 * **New Resource:** `vcfa_vcenter` to manage VMware Cloud Foundation Automation
-  vCenter servers [GH-2, GH-36]
+  vCenter servers [GH-2, GH-36, GH-45]
 * **New Data Source:** `vcfa_vcenter` to read VMware Cloud Foundation Automation
   vCenter servers [GH-2]

--- a/vcfa/resource_vcfa_content_library_item_test.go
+++ b/vcfa/resource_vcfa_content_library_item_test.go
@@ -14,8 +14,8 @@ func TestAccVcfaContentLibraryItem(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vCenterHcl, vCenterHclRef := getVCenterHcl(t)
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
+	vCenterHcl, vCenterHclRef := getVCenterHcl(t, nsxManagerHclRef)
 	regionHcl, regionHclRef := getRegionHcl(t, vCenterHclRef, nsxManagerHclRef)
 	contentLibraryHcl, contentLibraryHclRef := getContentLibraryHcl(t, regionHclRef)
 

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -4,10 +4,11 @@ package vcfa
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -18,8 +19,8 @@ func TestAccVcfaContentLibraryProvider(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vCenterHcl, vCenterHclRef := getVCenterHcl(t)
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
+	vCenterHcl, vCenterHclRef := getVCenterHcl(t, nsxManagerHclRef)
 	regionHcl, regionHclRef := getRegionHcl(t, vCenterHclRef, nsxManagerHclRef)
 
 	var params = StringMap{
@@ -165,8 +166,8 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vCenterHcl, vCenterHclRef := getVCenterHcl(t)
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
+	vCenterHcl, vCenterHclRef := getVCenterHcl(t, nsxManagerHclRef)
 	regionHcl, regionHclRef := getRegionHcl(t, vCenterHclRef, nsxManagerHclRef)
 	vmClassesHcl, vmClassesRefs := getRegionVmClassesHcl(t, regionHclRef)
 

--- a/vcfa/resource_vcfa_edge_cluster_qos_test.go
+++ b/vcfa/resource_vcfa_edge_cluster_qos_test.go
@@ -13,8 +13,8 @@ func TestAccVcfaEdgeCluster(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vCenterHcl, vCenterHclRef := getVCenterHcl(t)
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
+	vCenterHcl, vCenterHclRef := getVCenterHcl(t, nsxManagerHclRef)
 	regionHcl, regionHclRef := getRegionHcl(t, vCenterHclRef, nsxManagerHclRef)
 	var params = StringMap{
 		"Testname":        t.Name(),

--- a/vcfa/resource_vcfa_ip_space_test.go
+++ b/vcfa/resource_vcfa_ip_space_test.go
@@ -15,8 +15,8 @@ func TestAccVcfaIpSpace(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vCenterHcl, vCenterHclRef := getVCenterHcl(t)
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
+	vCenterHcl, vCenterHclRef := getVCenterHcl(t, nsxManagerHclRef)
 	regionHcl, regionHclRef := getRegionHcl(t, vCenterHclRef, nsxManagerHclRef)
 	var params = StringMap{
 		"Testname":      t.Name(),

--- a/vcfa/resource_vcfa_org_region_quota_test.go
+++ b/vcfa/resource_vcfa_org_region_quota_test.go
@@ -15,8 +15,8 @@ func TestAccVcfaOrgRegionQuota(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vCenterHcl, vCenterHclRef := getVCenterHcl(t)
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
+	vCenterHcl, vCenterHclRef := getVCenterHcl(t, nsxManagerHclRef)
 	regionHcl, regionHclRef := getRegionHcl(t, vCenterHclRef, nsxManagerHclRef)
 	vmClassesHcl, vmClassesRefs := getRegionVmClassesHcl(t, regionHclRef)
 	var params = StringMap{

--- a/vcfa/resource_vcfa_org_regional_networking_test.go
+++ b/vcfa/resource_vcfa_org_regional_networking_test.go
@@ -13,8 +13,8 @@ func TestAccVcfaOrgRegionalNetworking(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vCenterHcl, vCenterHclRef := getVCenterHcl(t)
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
+	vCenterHcl, vCenterHclRef := getVCenterHcl(t, nsxManagerHclRef)
 	regionHcl, regionHclRef := getRegionHcl(t, vCenterHclRef, nsxManagerHclRef)
 	ipSpaceHcl, ipSpaceHclRef := getIpSpaceHcl(t, regionHclRef, "1", "1")
 	providerGatewayHcl, providerGatewayHclRef := getProviderGatewayHcl(t, regionHclRef, ipSpaceHclRef)

--- a/vcfa/resource_vcfa_provider_gateway_test.go
+++ b/vcfa/resource_vcfa_provider_gateway_test.go
@@ -13,8 +13,8 @@ func TestAccVcfaProviderGateway(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vCenterHcl, vCenterHclRef := getVCenterHcl(t)
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
+	vCenterHcl, vCenterHclRef := getVCenterHcl(t, nsxManagerHclRef)
 	regionHcl, regionHclRef := getRegionHcl(t, vCenterHclRef, nsxManagerHclRef)
 	ipSpace1Hcl, ipSpace1HclRef := getIpSpaceHcl(t, regionHclRef, "1", "1")
 	ipSpace2Hcl, ipSpace2HclRef := getIpSpaceHcl(t, regionHclRef, "2", "2")

--- a/vcfa/resource_vcfa_region_test.go
+++ b/vcfa/resource_vcfa_region_test.go
@@ -152,6 +152,7 @@ resource "vcfa_vcenter" "test" {
   username                 = "{{.VcenterUsername}}"
   password                 = "{{.VcenterPassword}}"
   is_enabled               = true
+  nsx_manager_id           = vcfa_nsx_manager.test.id
 }
 
 data "vcfa_supervisor" "test" {

--- a/vcfa/resource_vcfa_vcenter.go
+++ b/vcfa/resource_vcfa_vcenter.go
@@ -49,6 +49,12 @@ func resourceVcfaVcenter() *schema.Resource {
 				ForceNew:    true,
 				Description: fmt.Sprintf("Defines if the %s certificate should automatically be trusted", labelVcfaVirtualCenter),
 			},
+			"nsx_manager_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: fmt.Sprintf("%s ID that this %s uses", labelVcfaNsxManager, labelVcfaVirtualCenter),
+			},
 			"refresh_vcenter_on_create": {
 				Type:        schema.TypeBool,
 				Optional:    true,

--- a/vcfa/vcfa_common_test.go
+++ b/vcfa/vcfa_common_test.go
@@ -14,7 +14,7 @@ import (
 // getVCenterHcl gets a vCenter data source as first returned parameter and its HCL reference as second one,
 // only if a vCenter is already configured in VCFA. Otherwise, it returns a vCenter resource HCL as first returned parameter
 // and its HCL reference as second one, only if "createVCenter=true" in the testing configuration
-func getVCenterHcl(t *testing.T) (string, string) {
+func getVCenterHcl(t *testing.T, nsxManagerHclRef string) (string, string) {
 	tmClient := createTemporaryVCFAConnection(false)
 	vc, err := tmClient.GetVCenterByUrl(testConfig.Tm.VcenterUrl)
 	if err == nil {
@@ -42,6 +42,7 @@ resource "vcfa_vcenter" "vc" {
   username                   = "` + testConfig.Tm.VcenterUsername + `"
   password                   = "` + testConfig.Tm.VcenterPassword + `"
   is_enabled                 = true
+  nsx_manager_id             = ` + nsxManagerHclRef + `.id
 }
 `, "vcfa_vcenter.vc"
 }

--- a/website/docs/r/vcenter.html.markdown
+++ b/website/docs/r/vcenter.html.markdown
@@ -15,7 +15,11 @@ Provides a resource to manage vCenters in VMware Cloud Foundation Automation.
 ## Example Usage
 
 ```hcl
-resource "vcfa_vcenter" "test" {
+data "vcfa_nsx_manager" "demo" {
+  name = "nsx-manager-one"
+}
+
+resource "vcfa_vcenter" "demo" {
   name                    = "my-vCenter"
   url                     = "https://host"
   auto_trust_certificate  = true
@@ -23,6 +27,7 @@ resource "vcfa_vcenter" "test" {
   username                = "admin@vsphere.local"
   password                = "CHANGE-ME"
   is_enabled              = true
+  nsx_manager_id          = data.vcfa_nsx_manager.demo.id
 }
 ```
 
@@ -30,6 +35,7 @@ resource "vcfa_vcenter" "test" {
 
 The following arguments are supported:
 
+* `nsx_manager_id` - (Required) ID of existing NSX Manager that this vCenter server uses
 * `name` - (Required) A name for vCenter server
 * `description` - (Optional) An optional description for vCenter server
 * `username` - (Required) A username for authenticating to vCenter server


### PR DESCRIPTION
`vcfa_vcenter` adds a required field `nsx_manager_id` to enforce NSX Manager creation before vCenter creation.