### PR TITLE
provider.url should not require API path

### DIFF
--- a/.changes/v1.0.0/47-improvements.md
+++ b/.changes/v1.0.0/47-improvements.md
@@ -1,0 +1,2 @@
+* The `url` field in `provider` configuration does not require specifying API endpoint '/api/
+  [GH-47]

--- a/go.mod
+++ b/go.mod
@@ -85,4 +85,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250226135802-2813026de663
+replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227063136-20caa69c16cf

--- a/go.mod
+++ b/go.mod
@@ -84,3 +84,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+//replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v2.12.1-0.20211018060826-c7f8ab32330e
+replace github.com/vmware/go-vcloud-director/v3 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -84,5 +84,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-//replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v2.12.1-0.20211018060826-c7f8ab32330e
-replace github.com/vmware/go-vcloud-director/v3 => ../go-vcloud-director
+
+replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250226135802-2813026de663

--- a/go.mod
+++ b/go.mod
@@ -85,4 +85,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227063136-20caa69c16cf
+replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227095601-e5ee4160523e

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.0
-	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.34
+	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.35
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
 )
@@ -84,5 +84,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227095601-e5ee4160523e

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227095601-e5ee4160523e h1:pQWlW2vVy1jwtFpqoh7RbSr8VVuVCtONGp9B8x/ZQAc=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227095601-e5ee4160523e/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
@@ -196,6 +194,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.35 h1:Ozxzz0SCL17P7G0mTvW2N+mJC/HRdZxH5r8Qlx6n6MQ=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.35/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250226135802-2813026de663 h1:raE+3JPqXeG9CoFLwjuTriQdjj/UB2+wq3/P8ZtA8l8=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250226135802-2813026de663/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227063136-20caa69c16cf h1:opFlrSvBnf4o6SHRV17fFqhGVSxaocDZfFWetRpNUmQ=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227063136-20caa69c16cf/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227063136-20caa69c16cf h1:opFlrSvBnf4o6SHRV17fFqhGVSxaocDZfFWetRpNUmQ=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227063136-20caa69c16cf/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227095601-e5ee4160523e h1:pQWlW2vVy1jwtFpqoh7RbSr8VVuVCtONGp9B8x/ZQAc=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250227095601-e5ee4160523e/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250226135802-2813026de663 h1:raE+3JPqXeG9CoFLwjuTriQdjj/UB2+wq3/P8ZtA8l8=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250226135802-2813026de663/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
@@ -194,8 +196,6 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.33 h1:36VjFoathGAqw2Y68IvBQCpi/3UAqu8PqUFPiqrVcMI=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.33/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/vcfa/resource_vcfa_vcenter.go
+++ b/vcfa/resource_vcfa_vcenter.go
@@ -398,7 +398,7 @@ func autoTrustHostCertificate(urlSchemaFieldName, trustSchemaFieldName string) s
 			return fmt.Errorf("error parsing provided url '%s': %s", schemaUrl, err)
 		}
 
-		_, err = tmClient.AutoTrustCertificate(parsedUrl)
+		_, err = tmClient.AutoTrustHttpsCertificate(parsedUrl, nil)
 		if err != nil {
 			return fmt.Errorf("error trusting '%s' certificate: %s", schemaUrl, err)
 		}

--- a/vcfa/sample_vcfa_test_config-cci.json
+++ b/vcfa/sample_vcfa_test_config-cci.json
@@ -7,7 +7,7 @@
         "tmVersion": "10.7.0",
         "tmApiVersion": "40.0",
         "token": "",
-        "url": "https://10.13.21.20/tm/api",
+        "url": "https://10.13.21.20",
         "sysOrg": "System",
         "allowInsecure": true,
         "tfAcceptanceTests": true,
@@ -24,6 +24,6 @@
         "region": "terraform-demo",
         "vpc": "terraform-demo-Default-VPC",
         "storagePolicy": "vSAN Default Storage Policy",
-        "supervisorZone": "vcfa-gen-wl-vc08-cl1-zone1"
+        "supervisorZone": "terraform-demo"
     }
 }

--- a/vcfa/sample_vcfa_test_config.json
+++ b/vcfa/sample_vcfa_test_config.json
@@ -11,7 +11,7 @@
     "//": "Access token to be used instead of username/password",
     "token": "",
 
-    "url": "https://10.13.21.20/tm/api",
+    "url": "https://myhostname.nonexistent",
     "sysOrg": "System",
     "//": "allowInsecure will skip the check on self-signed certificates",
     "allowInsecure": true,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -145,14 +145,9 @@ The following arguments are used to configure the VMware Cloud Foundation Automa
   `org` may be set to "System" when connection as Sys Admin is desired
   (set `user` to "administrator" in this case).  
   Note: `org` value is case sensitive.
-  
-- `sysorg` - (Optional) - Organization for user authentication. Can also be
-   specified with the `VCFA_SYS_ORG` environment variable. Set `sysorg` to "System" and
-   `user` to "administrator" to free up `org` argument for setting a default organization
-   for resources to use.
-   
+
 - `url` - (Required) This is the URL for the Tenant Manager API endpoint. e.g.
-  https://server.domain.com/tm/api. Can also be specified with the `VCFA_URL` environment variable.
+  https://server.domain.com. Can also be specified with the `VCFA_URL` environment variable.
 
 - `allow_unverified_ssl` - (Optional) Boolean that can be set to true to
   disable SSL certificate verification. This should be used with care as it

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -139,14 +139,14 @@ The following arguments are used to configure the VMware Cloud Foundation Automa
   if set to `true`, will suppress a warning to the user about the service account token file containing *sensitive information*.
   Can also be set with `VCFA_ALLOW_SA_TOKEN_FILE`.
 
-- `org` - (Required) This is the Tenant Manager Org on which to run API
+- `org` - (Required) This is the VCFA Org on which to run API
   operations. Can also be specified with the `VCFA_ORG` environment
   variable.  
   `org` may be set to "System" when connection as Sys Admin is desired
   (set `user` to "administrator" in this case).  
   Note: `org` value is case sensitive.
 
-- `url` - (Required) This is the URL for the Tenant Manager API endpoint. e.g.
+- `url` - (Required) This is the URL for the VCFA endpoint hostname e.g.
   https://server.domain.com. Can also be specified with the `VCFA_URL` environment variable.
 
 - `allow_unverified_ssl` - (Optional) Boolean that can be set to true to


### PR DESCRIPTION
The `url` field in `provider` configuration does not require specifying API endpoint suffix `/tm/api` which is backed by https://github.com/vmware/go-vcloud-director/pull/765 change

Tests are passing.