### PR TITLE
Patch TestAccDatasourceNotFound, bump SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,4 +86,4 @@ require (
 )
 
 //replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v2.12.1-0.20211018060826-c7f8ab32330e
-replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302092142-a4897c8108da
+replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302102010-1f509e5a9043

--- a/go.mod
+++ b/go.mod
@@ -86,4 +86,4 @@ require (
 )
 
 //replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v2.12.1-0.20211018060826-c7f8ab32330e
-replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302082823-1735cb0a69b9
+replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302092142-a4897c8108da

--- a/go.mod
+++ b/go.mod
@@ -86,4 +86,4 @@ require (
 )
 
 //replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v2.12.1-0.20211018060826-c7f8ab32330e
-replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302102010-1f509e5a9043
+replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302123138-e1bf09d452cb

--- a/go.mod
+++ b/go.mod
@@ -84,3 +84,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+//replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v2.12.1-0.20211018060826-c7f8ab32330e
+replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302082823-1735cb0a69b9

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.0
-	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.35
+	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.36
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
 )
@@ -84,6 +84,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-//replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v2.12.1-0.20211018060826-c7f8ab32330e
-replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250303095705-a0ae42f8e39b

--- a/go.mod
+++ b/go.mod
@@ -86,4 +86,4 @@ require (
 )
 
 //replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v2.12.1-0.20211018060826-c7f8ab32330e
-replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302123138-e1bf09d452cb
+replace github.com/vmware/go-vcloud-director/v3 => github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250303095705-a0ae42f8e39b

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302092142-a4897c8108da h1:Mnl5WS8ewm53RLiYoQLuSvLs4y0nB6pIxEYg/CPZvlA=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302092142-a4897c8108da/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302102010-1f509e5a9043 h1:7tkyZYCl8brCaAJSdOokohUrDXxg4iGFF2q/7qdrKeI=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302102010-1f509e5a9043/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302123138-e1bf09d452cb h1:KId0fA0XGPtFSAATDWkszMIoExEVRfiFljBmlBXdkI4=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302123138-e1bf09d452cb/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250303095705-a0ae42f8e39b h1:3YaNtX+A7zYwaC0A19DtxFo2BAk9LZ415a6Y9gd4Mw4=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250303095705-a0ae42f8e39b/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302102010-1f509e5a9043 h1:7tkyZYCl8brCaAJSdOokohUrDXxg4iGFF2q/7qdrKeI=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302102010-1f509e5a9043/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302123138-e1bf09d452cb h1:KId0fA0XGPtFSAATDWkszMIoExEVRfiFljBmlBXdkI4=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302123138-e1bf09d452cb/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250303095705-a0ae42f8e39b h1:3YaNtX+A7zYwaC0A19DtxFo2BAk9LZ415a6Y9gd4Mw4=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250303095705-a0ae42f8e39b/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
@@ -196,6 +194,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.36 h1:SCp2B/Rzv+shc26IIww46WocKMBo/vecHo7Q3skpGpo=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.36/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302082823-1735cb0a69b9 h1:LDA573lIruoB6mLg89ZNhArB0gP8y+sBYkHySYyjuMw=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302082823-1735cb0a69b9/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
@@ -194,8 +196,6 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.35 h1:Ozxzz0SCL17P7G0mTvW2N+mJC/HRdZxH5r8Qlx6n6MQ=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.35/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302082823-1735cb0a69b9 h1:LDA573lIruoB6mLg89ZNhArB0gP8y+sBYkHySYyjuMw=
-github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302082823-1735cb0a69b9/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302092142-a4897c8108da h1:Mnl5WS8ewm53RLiYoQLuSvLs4y0nB6pIxEYg/CPZvlA=
+github.com/Didainius/go-vcloud-director/v3 v3.0.0-alpha.4.0.20250302092142-a4897c8108da/go.mod h1:f/DvucDnptuPwnE01gmcnr3dS9AcQpv4KguP686IREs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=

--- a/vcfa/datasource_not_found_test.go
+++ b/vcfa/datasource_not_found_test.go
@@ -53,6 +53,14 @@ func testSpecificDataSourceNotFound(dataSourceName string, tmClient *VCDClient) 
 				dataSourceName: "vcfa_supervisor_zone",
 				reason:         "TODO: TM: Retrieving non-existent Supervisor by ID returns 400 and not ENF",
 			},
+			{
+				dataSourceName: "vcfa_provider_ldap",
+				reason:         "Data source vcfa_provider_ldap always returns data, it is not possible to get ENF",
+			},
+			{
+				dataSourceName: "vcfa_supervisor_namespace",
+				reason:         "Data source vcfa_supervisor_namespace requires different auth mechanism",
+			},
 		}
 		for _, skip := range skipAlwaysSlice {
 			if dataSourceName == skip.dataSourceName {

--- a/vcfa/resource_vcfa_vcenter.go
+++ b/vcfa/resource_vcfa_vcenter.go
@@ -207,12 +207,11 @@ func resourceVcfaVcenterCreate(ctx context.Context, d *schema.ResourceData, meta
 	shouldRefreshPolicies := d.Get("refresh_policies_on_create").(bool)
 	shouldWaitForListenerStatus := true
 	c := crudConfig[*govcd.VCenter, types.VSphereVirtualCenter]{
-		entityLabel:    labelVcfaVirtualCenter,
-		getTypeFunc:    getVcenterType,
-		stateStoreFunc: setVcenterData,
-		// createAsyncFunc:  tmClient.CreateVcenterAsync,
-		createFunc: tmClient.CreateVcenter,
-		// getEntityFunc:    tmClient.GetVCenterById,
+		entityLabel:      labelVcfaVirtualCenter,
+		getTypeFunc:      getVcenterType,
+		stateStoreFunc:   setVcenterData,
+		createAsyncFunc:  tmClient.CreateVcenterAsync,
+		getEntityFunc:    tmClient.GetVCenterById,
 		resourceReadFunc: resourceVcfaVcenterRead,
 		// certificate should be trusted for the vCenter to work
 		preCreateHooks: []schemaHook{autoTrustHostCertificate("url", "auto_trust_certificate")},

--- a/vcfa/resource_vcfa_vcenter.go
+++ b/vcfa/resource_vcfa_vcenter.go
@@ -207,11 +207,12 @@ func resourceVcfaVcenterCreate(ctx context.Context, d *schema.ResourceData, meta
 	shouldRefreshPolicies := d.Get("refresh_policies_on_create").(bool)
 	shouldWaitForListenerStatus := true
 	c := crudConfig[*govcd.VCenter, types.VSphereVirtualCenter]{
-		entityLabel:      labelVcfaVirtualCenter,
-		getTypeFunc:      getVcenterType,
-		stateStoreFunc:   setVcenterData,
-		createAsyncFunc:  tmClient.CreateVcenterAsync,
-		getEntityFunc:    tmClient.GetVCenterById,
+		entityLabel:    labelVcfaVirtualCenter,
+		getTypeFunc:    getVcenterType,
+		stateStoreFunc: setVcenterData,
+		// createAsyncFunc:  tmClient.CreateVcenterAsync,
+		createFunc: tmClient.CreateVcenter,
+		// getEntityFunc:    tmClient.GetVCenterById,
 		resourceReadFunc: resourceVcfaVcenterRead,
 		// certificate should be trusted for the vCenter to work
 		preCreateHooks: []schemaHook{autoTrustHostCertificate("url", "auto_trust_certificate")},


### PR DESCRIPTION
This PR patches broken TestAccDatasourceNotFound subtests and pulls in SDK from https://github.com/vmware/go-vcloud-director/pull/767

