### PR TITLE
Trigger cleanup after failed test to avoid resource clashes

### DIFF
--- a/.changes/v1.0.0/52-notes.md
+++ b/.changes/v1.0.0/52-notes.md
@@ -1,0 +1,1 @@
+* Artifact cleanup will be attempted immediately after a failed test [GH-52]

--- a/vcfa/config_test.go
+++ b/vcfa/config_test.go
@@ -898,6 +898,23 @@ func preTestChecks(t *testing.T) {
 // 2) stores file name in the "pass" or "fail" list, depending on their outcome. The lists are distinct by VCFA IP
 // 3) increments the pass/fail counters
 func postTestChecks(t *testing.T) {
+	if t.Failed() && !skipLeftoversRemoval {
+		tmClient, err := getTestVCFAFromJson(testConfig)
+		if err != nil {
+			t.Logf("error getting a govcd client: %s\n", err)
+
+		} else {
+			err = ProviderAuthenticate(tmClient, testConfig.Provider.User, testConfig.Provider.Password, testConfig.Provider.Token, testConfig.Provider.SysOrg, testConfig.Provider.ApiToken, testConfig.Provider.ApiTokenFile, testConfig.Provider.ServiceAccountTokenFile)
+			if err != nil {
+				t.Logf("error authenticating provider: %s\n", err)
+			}
+			err := removeLeftovers(tmClient, !silentLeftoversRemoval)
+			if err != nil {
+				t.Logf("error during leftover removal: %s\n", err)
+			}
+		}
+	}
+
 	// if the test runs without -vcfa-pre-post-checks, all post-checks will be skipped
 	if !vcfaPrePostChecks {
 		return

--- a/vcfa/datasource_not_found_test.go
+++ b/vcfa/datasource_not_found_test.go
@@ -16,6 +16,8 @@ import (
 // is not found.
 func TestAccDataSourceNotFound(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
+
 	// Exit the test early
 	if vcfaShortTest {
 		t.Skip(acceptanceTestsSkipped)
@@ -29,7 +31,6 @@ func TestAccDataSourceNotFound(t *testing.T) {
 	for _, dataSource := range Provider().DataSources() {
 		t.Run(dataSource.Name, testSpecificDataSourceNotFound(dataSource.Name, tmClient))
 	}
-	postTestChecks(t)
 }
 
 func testSpecificDataSourceNotFound(dataSourceName string, tmClient *VCDClient) func(*testing.T) {

--- a/vcfa/datasource_vcfa_kubeconfig_test.go
+++ b/vcfa/datasource_vcfa_kubeconfig_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestAccVcfaKubeConfig(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 
 	ref, err := url.Parse(testConfig.Provider.Url)
 	if err != nil {
@@ -50,8 +51,6 @@ func TestAccVcfaKubeConfig(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaKubeConfigStep1 = `

--- a/vcfa/datasource_vcfa_right_test.go
+++ b/vcfa/datasource_vcfa_right_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccVcfaRight(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
@@ -46,8 +47,6 @@ func TestAccVcfaRight(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaRight = `

--- a/vcfa/datasource_vcfa_tm_version_test.go
+++ b/vcfa/datasource_vcfa_tm_version_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccVcfaTmVersion(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	tmClient := createSystemTemporaryVCFAConnection()
@@ -124,7 +125,6 @@ func TestAccVcfaTmVersion(t *testing.T) {
 			},
 		},
 	})
-	postTestChecks(t)
 }
 
 const testAccVcfaTmVersion = `

--- a/vcfa/resource_vcfa_api_token_test.go
+++ b/vcfa/resource_vcfa_api_token_test.go
@@ -16,6 +16,7 @@ import (
 // is provided instead of user + password, in test configuration
 func TestAccVcfaApiToken(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 
 	var params = StringMap{
 		"TokenName": t.Name(),
@@ -47,7 +48,6 @@ func TestAccVcfaApiToken(t *testing.T) {
 			},
 		},
 	})
-	postTestChecks(t)
 }
 
 // #nosec G101 -- No hardcoded credentials here

--- a/vcfa/resource_vcfa_certificate_test.go
+++ b/vcfa/resource_vcfa_certificate_test.go
@@ -3,9 +3,10 @@
 package vcfa
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -14,6 +15,8 @@ import (
 // testing configuration
 func TestAccVcfaCertificateResource(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
+
 	skipIfNotSysAdmin(t)
 
 	if len(testConfig.Tm.Certificates) < 2 {
@@ -121,7 +124,6 @@ func TestAccVcfaCertificateResource(t *testing.T) {
 			},
 		},
 	})
-	postTestChecks(t)
 }
 
 const testAccVcfaLibraryCertificateResource = `

--- a/vcfa/resource_vcfa_content_library_item_test.go
+++ b/vcfa/resource_vcfa_content_library_item_test.go
@@ -4,10 +4,11 @@ package vcfa
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -15,6 +16,7 @@ import (
 // TestAccVcfaContentLibraryItemProvider tests Content Library Items in a "PROVIDER" type Content Library
 func TestAccVcfaContentLibraryItemProvider(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
@@ -136,8 +138,6 @@ func TestAccVcfaContentLibraryItemProvider(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaContentLibraryItemProviderStep1 = `
@@ -181,6 +181,7 @@ data "vcfa_content_library_item" "cli3_ds" {
 // TestAccVcfaContentLibraryItemTenant tests Content Library Items in a "TENANT" type Content Library
 func TestAccVcfaContentLibraryItemTenant(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
@@ -411,8 +412,6 @@ func TestAccVcfaContentLibraryItemTenant(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaContentLibraryItemTenantStep4 = `

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -17,6 +17,7 @@ import (
 // It also tests vcfa_storage_class and vcfa_region_storage_policy data sources
 func TestAccVcfaContentLibraryProvider(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
@@ -154,8 +155,6 @@ func TestAccVcfaContentLibraryProvider(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaContentLibraryProviderStep1 = `
@@ -206,6 +205,7 @@ data "vcfa_content_library" "cl_subscribed_ds" {
 // TestAccVcfaContentLibraryTenant tests CRUD of a Content Library of type TENANT.
 func TestAccVcfaContentLibraryTenant(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
@@ -408,8 +408,6 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaContentLibraryTenantPrerequisites = `

--- a/vcfa/resource_vcfa_edge_cluster_qos_test.go
+++ b/vcfa/resource_vcfa_edge_cluster_qos_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccVcfaEdgeCluster(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
@@ -154,8 +155,6 @@ func TestAccVcfaEdgeCluster(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaEdgeClusterQosStep1 = `

--- a/vcfa/resource_vcfa_global_role_test.go
+++ b/vcfa/resource_vcfa_global_role_test.go
@@ -14,6 +14,7 @@ import (
 // is provided instead of user + password, in test configuration
 func TestAccVcfaGlobalRole(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	var globalRoleName = t.Name()
@@ -78,7 +79,6 @@ func TestAccVcfaGlobalRole(t *testing.T) {
 			},
 		},
 	})
-	postTestChecks(t)
 }
 
 func testAccCheckGlobalRoleExists(identifier string) resource.TestCheckFunc {

--- a/vcfa/resource_vcfa_ip_space_test.go
+++ b/vcfa/resource_vcfa_ip_space_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestAccVcfaIpSpace(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
@@ -117,8 +118,6 @@ func TestAccVcfaIpSpace(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaIpSpaceStep1 = `

--- a/vcfa/resource_vcfa_nsx_manager_test.go
+++ b/vcfa/resource_vcfa_nsx_manager_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccVcfaNsxManager(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	if !testConfig.Tm.CreateNsxManager {
@@ -79,8 +80,6 @@ func TestAccVcfaNsxManager(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaNsxManagerStep1 = `

--- a/vcfa/resource_vcfa_org_ldap_test.go
+++ b/vcfa/resource_vcfa_org_ldap_test.go
@@ -13,6 +13,7 @@ import (
 // TestAccVcfaOrgLdap tests LDAP configuration against an LDAP server with the given configuration
 func TestAccVcfaOrgLdap(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	if testConfig.Ldap.Host == "" || testConfig.Ldap.Username == "" || testConfig.Ldap.Password == "" || testConfig.Ldap.Type == "" ||
@@ -113,7 +114,6 @@ func TestAccVcfaOrgLdap(t *testing.T) {
 			},
 		},
 	})
-	postTestChecks(t)
 }
 
 func testAccCheckOrgLdapExists(identifier string) resource.TestCheckFunc {

--- a/vcfa/resource_vcfa_org_local_user_test.go
+++ b/vcfa/resource_vcfa_org_local_user_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccVcfaOrgLocalUser(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
@@ -71,8 +72,6 @@ func TestAccVcfaOrgLocalUser(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaLocalUserPrerequisites = `

--- a/vcfa/resource_vcfa_org_networking_test.go
+++ b/vcfa/resource_vcfa_org_networking_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccVcfaOrgNetworking(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
@@ -76,8 +77,6 @@ func TestAccVcfaOrgNetworking(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaOrgNetworkingStep1 = `

--- a/vcfa/resource_vcfa_org_oidc_test.go
+++ b/vcfa/resource_vcfa_org_oidc_test.go
@@ -5,16 +5,18 @@ package vcfa
 import (
 	_ "embed"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"net/url"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccVcfaOrgOidc(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	oidcServerUrl := validateAndGetOidcServerUrl(t, testConfig)
 
 	orgName1 := t.Name() + "1"
@@ -134,8 +136,6 @@ func TestAccVcfaOrgOidc(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 // TODO: TM: vcfa_org_oidc oidc1 should not override claims_mapping so it tests that the resource is able to set them

--- a/vcfa/resource_vcfa_org_region_quota_test.go
+++ b/vcfa/resource_vcfa_org_region_quota_test.go
@@ -13,6 +13,7 @@ import (
 // TODO: TM: Improve this test so it has more than 1 Region Storage Policy
 func TestAccVcfaOrgRegionQuota(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
@@ -126,8 +127,6 @@ func TestAccVcfaOrgRegionQuota(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaOrgRegionQuotaStep1 = `

--- a/vcfa/resource_vcfa_org_regional_networking_test.go
+++ b/vcfa/resource_vcfa_org_regional_networking_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccVcfaOrgRegionalNetworking(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
@@ -147,8 +148,6 @@ func TestAccVcfaOrgRegionalNetworking(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaOrgRegionalNetworkingPrerequisites = `

--- a/vcfa/resource_vcfa_org_test.go
+++ b/vcfa/resource_vcfa_org_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccVcfaOrg(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
@@ -82,8 +83,6 @@ func TestAccVcfaOrg(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaOrgStep1 = `
@@ -123,6 +122,7 @@ data "vcfa_org_settings" "allow_ds" {
 // TestAccVcfaOrgClassicTenant tests a Tenant Manager Organization configured as "Classic Tenant"
 func TestAccVcfaOrgClassicTenant(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
@@ -171,8 +171,6 @@ func TestAccVcfaOrgClassicTenant(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaOrgClassicStep1 = `

--- a/vcfa/resource_vcfa_provider_gateway_test.go
+++ b/vcfa/resource_vcfa_provider_gateway_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccVcfaProviderGateway(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	nsxManagerHcl, nsxManagerHclRef := getNsxManagerHcl(t)
@@ -114,8 +115,6 @@ func TestAccVcfaProviderGateway(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaProviderGatewayPrereqs = `

--- a/vcfa/resource_vcfa_provider_ldap_test.go
+++ b/vcfa/resource_vcfa_provider_ldap_test.go
@@ -13,6 +13,7 @@ import (
 // TestAccVcfaProviderLdap tests Provider (System) LDAP configuration against an LDAP server with the given configuration
 func TestAccVcfaProviderLdap(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	if testConfig.Ldap.Host == "" || testConfig.Ldap.Username == "" || testConfig.Ldap.Password == "" || testConfig.Ldap.Type == "" ||
@@ -93,7 +94,6 @@ func TestAccVcfaProviderLdap(t *testing.T) {
 			},
 		},
 	})
-	postTestChecks(t)
 }
 
 func testAccCheckLdapDestroy() resource.TestCheckFunc {

--- a/vcfa/resource_vcfa_region_test.go
+++ b/vcfa/resource_vcfa_region_test.go
@@ -14,6 +14,7 @@ import (
 // as the API does not support update yet
 func TestAccVcfaRegion(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
@@ -129,8 +130,6 @@ func TestAccVcfaRegion(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaRegionPrerequisites = `

--- a/vcfa/resource_vcfa_rights_bundle_test.go
+++ b/vcfa/resource_vcfa_rights_bundle_test.go
@@ -14,6 +14,7 @@ import (
 // is provided instead of user + password, in test configuration
 func TestAccVcfaRightsBundle(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	var rightsBundleName = t.Name()
@@ -78,7 +79,6 @@ func TestAccVcfaRightsBundle(t *testing.T) {
 			},
 		},
 	})
-	postTestChecks(t)
 }
 
 func testAccCheckRightsBundleExists(identifier string) resource.TestCheckFunc {

--- a/vcfa/resource_vcfa_role_test.go
+++ b/vcfa/resource_vcfa_role_test.go
@@ -16,6 +16,7 @@ import (
 // is provided instead of user + password, in test configuration
 func TestAccVcfaRole(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	var roleName = t.Name()
 	var roleUpdateName = t.Name() + "-update"
 	var roleDescription = "A long description containing some text."
@@ -78,7 +79,6 @@ func TestAccVcfaRole(t *testing.T) {
 			},
 		},
 	})
-	postTestChecks(t)
 }
 
 func testAccCheckRoleExists(orgId, roleId string) resource.TestCheckFunc {

--- a/vcfa/resource_vcfa_supervisor_namespace_test.go
+++ b/vcfa/resource_vcfa_supervisor_namespace_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestAccVcfaSupervisorNamespace(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfSysAdmin(t)
 
 	if vcfaShortTest {
@@ -103,8 +104,6 @@ func TestAccVcfaSupervisorNamespace(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaSupervisorNamespaceStep1 = `

--- a/vcfa/resource_vcfa_vcenter_test.go
+++ b/vcfa/resource_vcfa_vcenter_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccVcfaVcenter(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	if !testConfig.Tm.CreateVcenter {
@@ -118,8 +119,6 @@ func TestAccVcfaVcenter(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }
 
 const testAccVcfaVcenterPrerequisites = `
@@ -180,6 +179,7 @@ data "vcfa_vcenter" "test" {
 
 func TestAccVcfaVcenterInvalid(t *testing.T) {
 	preTestChecks(t)
+	defer postTestChecks(t)
 	skipIfNotSysAdmin(t)
 
 	// test fails on purpose
@@ -238,6 +238,4 @@ func TestAccVcfaVcenterInvalid(t *testing.T) {
 			},
 		},
 	})
-
-	postTestChecks(t)
 }


### PR DESCRIPTION
This PR attempts to trigger immediate cleanup after any failed test so that the next tests do not conflict for left behind duplicate entries. 

Two things are done:
* `postTestChecks` is deferred immediately after `preTestChecks` instead of keeping it at the end. This way it will be triggered even if the tests fail
* `postTestChecks` will trigger leftover removal code in case the test is marked as failed and the leftover removal is not explicitly skipped`t.Failed() && !skipLeftoversRemoval`

Caveat - if the test panics - it won't help, but panic is a hard error anyway

Example recovery cleanup:
```
=== RUN   TestAccVcfaCertificateResource
    resource_vcfa_certificate_test.go:69: Step 1/4 error: Error running apply: exit status 1

        Error: [certificate library read] : error in HTTP GET request: RESOURCE_NOT_FOUND - Resource not found

          with vcfa_certificate.orgCertificate,
          on terraform_plugin_test.tf line 12, in resource "vcfa_certificate" "orgCertificate":
          12: resource "vcfa_certificate" "orgCertificate" {


        Error: [certificate library read] : error in HTTP GET request: RESOURCE_NOT_FOUND - Resource not found

          with vcfa_certificate.OrgWithPrivateCertificate,
          on terraform_plugin_test.tf line 19, in resource "vcfa_certificate" "OrgWithPrivateCertificate":
          19: resource "vcfa_certificate" "OrgWithPrivateCertificate" {


        Error: error adding certificate library item: error in HTTP POST request: BAD_REQUEST - [ 29-2025-03-07-13-24-31-417--28434f7b-eca2-4a24-aef7-cc455ab87a67 ] Cannot upload duplicate Certificate Libr
ary items.

          with vcfa_certificate.sysCertificate,
          on terraform_plugin_test.tf line 28, in resource "vcfa_certificate" "sysCertificate":
          28: resource "vcfa_certificate" "sysCertificate" {


        Error: error adding certificate library item: error in HTTP POST request: BAD_REQUEST - [ 30-2025-03-07-13-24-32-017--a727045d-36f8-412b-b373-4a5db116a646 ] Cannot upload duplicate Certificate Libr
ary items.

          with vcfa_certificate.sysCertificateWithPrivate,
          on terraform_plugin_test.tf line 35, in resource "vcfa_certificate" "sysCertificateWithPrivate":
          35: resource "vcfa_certificate" "sysCertificateWithPrivate" {

    testing_new.go:85: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: [certificate library delete] error fetching certificate library: error in HTTP GET request: RESOURCE_NOT_FOUND - Resource not found


        Error: [certificate library delete] error fetching certificate library: error in HTTP GET request: RESOURCE_NOT_FOUND - Resource not found

Start leftovers removal    <------------- immediate cleanup
[vcfa_org] System (keep -)
[vcfa_org] test-org (DELETE)
         REMOVING Organization test-org
End leftovers removal
--- FAIL: TestAccVcfaCertificateResource (38.82s)
=== RUN   TestAccVcfaOrg
--- PASS: TestAccVcfaOrg (28.92s)
FAIL
Start leftovers removal. <------------- final cleanup that already exists
[vcfa_org] System (keep -)
End leftovers removal
FAIL    github.com/vmware/terraform-provider-vcfa/vcfa  83.386s
FAIL
```