### PR TITLE
Fix NOT_AUTHENTICATED errors in Content Library tests

### DIFF
--- a/.changes/v1.0.0/12-features.md
+++ b/.changes/v1.0.0/12-features.md
@@ -1,4 +1,4 @@
-- **New Resource:** `vcfa_content_library` to manage Content Libraries [GH-12, GH-42, GH-43, GH-50]
-- **New Data Source:** `vcfa_content_library` to read Content Libraries [GH-12, GH-42, GH-50]
+- **New Resource:** `vcfa_content_library` to manage Content Libraries [GH-12, GH-42, GH-43, GH-50, GH-53]
+- **New Data Source:** `vcfa_content_library` to read Content Libraries [GH-12, GH-42, GH-50, GH-53]
 - **New Data Source:** `vcfa_region_storage_policy` to read Region Storage Policies [GH-12]
 - **New Data Source:** `vcfa_storage_class` to read Storage Classes [GH-12]

--- a/.changes/v1.0.0/13-features.md
+++ b/.changes/v1.0.0/13-features.md
@@ -1,2 +1,2 @@
-* **New Resource:** `vcfa_content_library_item` to manage Content Library Items [GH-13, GH-46, GH-50]
+* **New Resource:** `vcfa_content_library_item` to manage Content Library Items [GH-13, GH-46, GH-50, GH-53]
 * **New Data Source:** `vcfa_content_library_item` to read Content Library Items [GH-13]

--- a/vcfa/config.go
+++ b/vcfa/config.go
@@ -72,6 +72,14 @@ type cacheStorage struct {
 	sync.Mutex
 }
 
+// reset clears cache to force re-authentication
+func (c *cacheStorage) reset() {
+	c.Lock()
+	defer c.Unlock()
+	c.cacheClientServedCount = 0
+	c.conMap = make(map[string]cachedConnection)
+}
+
 var (
 	// Enables the caching of authenticated connections
 	enableConnectionCache = os.Getenv("VCFA_CACHE") != ""

--- a/vcfa/resource_vcfa_content_library_item_test.go
+++ b/vcfa/resource_vcfa_content_library_item_test.go
@@ -261,6 +261,11 @@ func TestAccVcfaContentLibraryItemTenant(t *testing.T) {
 		}
 	}
 
+	// Before this test ends we need to clean up the clients cache, because we create an Org user
+	// and use it to login with the provider. Using same credentials and org name could lead to errors if this user
+	// remains cached.
+	defer cachedVCDClients.reset()
+
 	resource.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -282,6 +282,11 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 		}
 	}
 
+	// Before this test ends we need to clean up the clients cache, because we create an Org user
+	// and use it to login with the provider. Using same credentials and org name could lead to errors if this user
+	// remains cached.
+	defer cachedVCDClients.reset()
+
 	resource.Test(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -428,7 +428,7 @@ resource "vcfa_org" "test" {
 resource "vcfa_org_settings" "allow" {
   org_id                           = vcfa_org.test.id
   can_create_subscribed_libraries  = true
-  quarantine_content_library_items = true
+  quarantine_content_library_items = false
 }
 
 data "vcfa_role" "org-admin" {


### PR DESCRIPTION
This PR fixes the test failure:

```
=== RUN   TestAccVcfaContentLibraryTenant
    resource_vcfa_content_library_test.go:285: Step 4/6 error: Error running pre-apply refresh: exit status 1
        
        Error: error getting Storage Class by Name 'vSAN Default Storage Policy': error retrieving all entities of type 'Storage Class': error getting all pages for endpoint https://my-vcfa.com/cloudapi/vcf/storageClasses/: error in HTTP GET request: NOT_AUTHENTICATED - [ 3258-2025-03-07-00-07-32-260--218b64dc-ad8d-43c6-9f9f-4c6eff270d9e ] This operation is denied.
        
          with data.vcfa_storage_class.sc-tenant,
          on terraform_plugin_test.tf line 167, in data "vcfa_storage_class" "sc-tenant":
         167: data "vcfa_storage_class" "sc-tenant" {
        
--- FAIL: TestAccVcfaContentLibraryTenant (220.57s)
```

The issue happens because there is one test, `TestAccVcfaContentLibraryItemTenant`, which is run before `TestAccVcfaContentLibraryTenant`, that creates an Organization user and performs a login with it, caching its data in the client cache. When the test finishes, the user is destroyed, but it remains in the client cache.

When `TestAccVcfaContentLibraryTenant` kicks in afterwards, it creates again the same user (it re-uses same HCL), so when the login comes, it reuses wrong cached info, therefore all subsequent queries will end up with `NOT_AUTHENTICATED` errors.

The fix consists of resetting the cached clients when these kind of tests complete.

**Extra fix:** Disable anti-virus scanning in created Org in these tests, to avoid blocking tasks.

To reproduce:
```
go test -tags functional -vcfa-add-provider -run 'TestAccVcfaContentLibraryTenant|TestAccVcfaContentLibraryItemTenant' -v -timeout 0
```

This will fail without this fix with the error above. With the fix, both should pass