### PR TITLE
Improve LDAP password management

### DIFF
--- a/.changes/v1.0.0/26-features.md
+++ b/.changes/v1.0.0/26-features.md
@@ -1,4 +1,4 @@
-- **New Resource:** `vcfa_org_ldap` to manage LDAP settings of Organizations [GH-26, GH-28, GH-50, GH-61]
-- **New Data Source:** `vcfa_org_ldap` to read LDAP settings of Organizations [GH-26, GH-28, GH-50, GH-61]
-- **New Resource:** `vcfa_provider_ldap` to manage global Provider LDAP settings [GH-28]
-- **New Data Source:** `vcfa_provider_ldap` to read global Provider LDAP settings [GH-28]
+- **New Resource:** `vcfa_org_ldap` to manage LDAP settings of Organizations [GH-26, GH-28, GH-50, GH-61, GH-65]
+- **New Data Source:** `vcfa_org_ldap` to read LDAP settings of Organizations [GH-26, GH-28, GH-50, GH-61, GH-65]
+- **New Resource:** `vcfa_provider_ldap` to manage global Provider LDAP settings [GH-28, GH-65]
+- **New Data Source:** `vcfa_provider_ldap` to read global Provider LDAP settings [GH-28, GH-65]

--- a/vcfa/datasource_vcfa_org_ldap.go
+++ b/vcfa/datasource_vcfa_org_ldap.go
@@ -77,5 +77,5 @@ func datasourceVcfaOrgLdap() *schema.Resource {
 }
 
 func datasourceVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return genericVcfaOrgLdapRead(ctx, d, meta, "datasource")
+	return genericVcfaOrgLdapRead(ctx, d, meta, "datasource", nil)
 }

--- a/vcfa/resource_vcfa_org_ldap.go
+++ b/vcfa/resource_vcfa_org_ldap.go
@@ -241,6 +241,16 @@ func resourceVcfaOrgLdap() *schema.Resource {
 	}
 }
 
+func resourceVcfaOrgLdapCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceVcfaOrgLdapCreateOrUpdate(ctx, d, meta, "resource")
+}
+func resourceVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcfaOrgLdapRead(ctx, d, meta, "resource", nil)
+}
+func resourceVcfaOrgLdapUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceVcfaOrgLdapCreateOrUpdate(ctx, d, meta, "resource")
+}
+
 func resourceVcfaOrgLdapCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}, origin string) diag.Diagnostics {
 	// Lock the Organization to serialize create/update operation and prevent side effects like bricked Organizations when
 	// vcfa_org_settings is updated at the same time
@@ -264,17 +274,7 @@ func resourceVcfaOrgLdapCreateOrUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("[Org LDAP %s] error setting org '%s' LDAP configuration: %s", origin, orgId, err)
 	}
 
-	return genericVcfaOrgLdapRead(ctx, d, meta, "create", settings)
-}
-
-func resourceVcfaOrgLdapCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceVcfaOrgLdapCreateOrUpdate(ctx, d, meta, "create")
-}
-func resourceVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return genericVcfaOrgLdapRead(ctx, d, meta, "resource", nil)
-}
-func resourceVcfaOrgLdapUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceVcfaOrgLdapCreateOrUpdate(ctx, d, meta, "update")
+	return genericVcfaOrgLdapRead(ctx, d, meta, origin, settings)
 }
 
 func genericVcfaOrgLdapRead(_ context.Context, d *schema.ResourceData, meta interface{}, origin string, settings *types.OrgLdapSettingsType) diag.Diagnostics {

--- a/vcfa/resource_vcfa_org_ldap.go
+++ b/vcfa/resource_vcfa_org_ldap.go
@@ -263,17 +263,21 @@ func resourceVcfaOrgLdapCreateOrUpdate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.Errorf("[Org LDAP %s] error setting org '%s' LDAP configuration: %s", origin, orgId, err)
 	}
-	return resourceVcfaOrgLdapRead(ctx, d, meta)
+
+	return genericVcfaOrgLdapRead(ctx, d, meta, "create", settings)
 }
 
 func resourceVcfaOrgLdapCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return resourceVcfaOrgLdapCreateOrUpdate(ctx, d, meta, "create")
 }
 func resourceVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return genericVcfaOrgLdapRead(ctx, d, meta, "resource")
+	return genericVcfaOrgLdapRead(ctx, d, meta, "resource", nil)
+}
+func resourceVcfaOrgLdapUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceVcfaOrgLdapCreateOrUpdate(ctx, d, meta, "update")
 }
 
-func genericVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}, origin string) diag.Diagnostics {
+func genericVcfaOrgLdapRead(_ context.Context, d *schema.ResourceData, meta interface{}, origin string, settings *types.OrgLdapSettingsType) diag.Diagnostics {
 	tmClient := meta.(ClientContainer).tmClient
 	orgId := d.Get("org_id").(string)
 
@@ -338,20 +342,26 @@ func genericVcfaOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if origin == "resource" {
-			// The password field does not exist in data source as it's never returned.
-			// Here we set it explicitly to be reminded of that fact, only for the resource.
-			customSettings["password"] = ""
+			if settings != nil && settings.CustomOrgLdapSettings != nil && settings.CustomOrgLdapSettings.Password != "" {
+				// This will be true on Create and Update, as we pass the original LDAP settings as parameter to this function.
+				// This way we can save the original password that the user set on create or update.
+				customSettings["password"] = settings.CustomOrgLdapSettings.Password
+			} else {
+				// This happens on Reads. We don't have original settings (Read operations pass this parameter as nil).
+				// In this case, we recover the password from state.
+				oldSettings := d.Get("custom_settings").([]interface{})
+				if len(oldSettings) > 0 {
+					customSettings["password"] = oldSettings[0].(map[string]interface{})["password"]
+				}
+			}
 		}
+
 		err = d.Set("custom_settings", []map[string]interface{}{customSettings})
 		if err != nil {
 			return diag.Errorf("[Org LDAP read %s] error setting 'user_attributes' field: %s", origin, err)
 		}
 	}
 	return nil
-}
-
-func resourceVcfaOrgLdapUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourceVcfaOrgLdapCreateOrUpdate(ctx, d, meta, "update")
 }
 
 func resourceVcfaOrgLdapDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/vcfa/resource_vcfa_org_ldap.go
+++ b/vcfa/resource_vcfa_org_ldap.go
@@ -347,7 +347,7 @@ func genericVcfaOrgLdapRead(_ context.Context, d *schema.ResourceData, meta inte
 				// This way we can save the original password that the user set on create or update.
 				customSettings["password"] = settings.CustomOrgLdapSettings.Password
 			} else {
-				// This happens on Reads. We don't have original settings (Read operations pass this parameter as nil).
+				// This happens on Reads. We don't have original settings (Read operations pass 'settings' parameter as nil).
 				// In this case, we recover the password from state.
 				oldSettings := d.Get("custom_settings").([]interface{})
 				if len(oldSettings) > 0 {

--- a/vcfa/resource_vcfa_org_ldap_test.go
+++ b/vcfa/resource_vcfa_org_ldap_test.go
@@ -70,7 +70,7 @@ func TestAccVcfaOrgLdap(t *testing.T) {
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.base_distinguished_name", testConfig.Ldap.BaseDistinguishedName),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.connector_type", testConfig.Ldap.Type),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.custom_ui_button_label", "Hello there"),
-					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.password", ""), // Password is not returned
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.password", testConfig.Ldap.Password),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.user_attributes.0.object_class", "user"),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.user_attributes.0.unique_identifier", "objectGuid"),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.user_attributes.0.display_name", "displayName"),

--- a/vcfa/resource_vcfa_org_ldap_test.go
+++ b/vcfa/resource_vcfa_org_ldap_test.go
@@ -110,7 +110,7 @@ func TestAccVcfaOrgLdap(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       func(state *terraform.State) (string, error) { return testConfig.Tm.Org, nil },
-				ImportStateVerifyIgnore: []string{"auto_trust_certificate"},
+				ImportStateVerifyIgnore: []string{"auto_trust_certificate", "custom_settings.0.password"},
 			},
 		},
 	})

--- a/vcfa/resource_vcfa_provider_ldap.go
+++ b/vcfa/resource_vcfa_provider_ldap.go
@@ -188,11 +188,6 @@ func saveTmLdapSettingsInState(d *schema.ResourceData, config *types.TmLdapSetti
 	dSet(d, "connector_type", config.ConnectorType)
 	dSet(d, "is_ssl", config.IsSsl)
 	dSet(d, "username", config.UserName)
-	if origin == "resource" {
-		// The password field does not exist in data source as it's never returned.
-		// Here we set it explicitly to be reminded of that fact, but only in the resource.
-		dSet(d, "password", "")
-	}
 	if config.CustomUiButtonLabel != nil {
 		dSet(d, "custom_ui_button_label", *config.CustomUiButtonLabel)
 	}

--- a/vcfa/resource_vcfa_provider_ldap_test.go
+++ b/vcfa/resource_vcfa_provider_ldap_test.go
@@ -60,7 +60,7 @@ func TestAccVcfaProviderLdap(t *testing.T) {
 					resource.TestCheckResourceAttr(ldapResourceDef, "base_distinguished_name", testConfig.Ldap.BaseDistinguishedName),
 					resource.TestCheckResourceAttr(ldapResourceDef, "connector_type", testConfig.Ldap.Type),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_ui_button_label", "Hello there"),
-					resource.TestCheckResourceAttr(ldapResourceDef, "password", ""), // Password is not returned
+					resource.TestCheckResourceAttr(ldapResourceDef, "password", testConfig.Ldap.Password),
 					resource.TestCheckResourceAttr(ldapResourceDef, "user_attributes.0.object_class", "user"),
 					resource.TestCheckResourceAttr(ldapResourceDef, "user_attributes.0.unique_identifier", "objectGuid"),
 					resource.TestCheckResourceAttr(ldapResourceDef, "user_attributes.0.display_name", "displayName"),

--- a/vcfa/resource_vcfa_provider_ldap_test.go
+++ b/vcfa/resource_vcfa_provider_ldap_test.go
@@ -90,7 +90,7 @@ func TestAccVcfaProviderLdap(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       func(state *terraform.State) (string, error) { return testConfig.Tm.Org, nil },
-				ImportStateVerifyIgnore: []string{"auto_trust_certificate"},
+				ImportStateVerifyIgnore: []string{"auto_trust_certificate", "password"},
 			},
 		},
 	})

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -55,22 +55,6 @@ resource "vcfa_org_ldap" "my-org-ldap" {
 }
 ```
 
--> **Note** 
-The password value never gets returned by GET. Therefore, if we want `terraform plan` to return a clean state, we need
-to add a `lifecycle` block at the end of the resource definition, after creating or updating it.
-And we need to remove the `lifecycle` block _if we want to change the password_.
-
-```hcl
-resource "vcfa_org_ldap" "my-org-ldap" {
-  # all other fields
-  # ...
-  lifecycle {
-    # password value does not get returned by GET
-    ignore_changes = [custom_settings[0].password]
-  }
-}
-```
-
 ## Example Usage 2 - Using system configuration
 
 ```hcl
@@ -109,9 +93,7 @@ The `custom_settings` section contains the configuration for the LDAP server
 * `is_ssl` - (Optional) True if the LDAP service requires an SSL connection. If the certificate is not trusted already, `auto_trust_certificate=true` is needed.
 * `username` - (Optional) _Username_ to use when logging in to LDAP, specified using LDAP attribute=value pairs 
   (for example: cn="ldap-admin", c="example", dc="com")
-* `password` - (Optional) _Password_ for the user identified by UserName. This value is never returned by GET. 
-   It is inspected on create and modify. On modify, the absence of this element indicates that the password should not be changed
-
+* `password` - (Optional) _Password_ for the user identified by `username`. This value is never returned on reads
 * `user_attributes` - (Required) User settings when `ldap_mode` is `CUSTOM` See [User Attributes](#user-attributes) below for details
 * `group_attributes` - (Required) Group settings when `ldap_mode` is `CUSTOM` See [Group Attributes](#group-attributes) below for details
 

--- a/website/docs/r/provider_ldap.html.markdown
+++ b/website/docs/r/provider_ldap.html.markdown
@@ -47,23 +47,6 @@ resource "vcfa_provider_ldap" "global-ldap" {
 }
 ```
 
--> **Note** 
-The password value never gets returned by GET. Therefore, if we want `terraform plan` to return a clean state, we need
-to add a `lifecycle` block at the end of the resource definition, after creating or updating it.
-And we need to remove the `lifecycle` block _if we want to change the password_.
-
-```hcl
-resource "vcfa_provider_ldap" "global-ldap" {
-  # all other fields
-  # ...
-  lifecycle {
-    # password value does not get returned by GET
-    ignore_changes = [password]
-  }
-}
-```
-
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -77,9 +60,7 @@ The following arguments are supported:
 * `is_ssl` - (Optional) True if the LDAP service requires an SSL connection. If the certificate is not trusted already, `auto_trust_certificate=true` is needed.
 * `username` - (Optional) _Username_ to use when logging in to LDAP, specified using LDAP attribute=value pairs 
   (for example: cn="ldap-admin", c="example", dc="com")
-* `password` - (Optional) _Password_ for the user identified by UserName. This value is never returned by GET. 
-   It is inspected on create and modify. On modify, the absence of this element indicates that the password should not be changed
-
+* `password` - (Optional) _Password_ for the user identified by `username`. This value is never returned on reads
 * `user_attributes` - (Required) User settings. See [User Attributes](#user-attributes) below for details
 * `group_attributes` - (Required) Group settings. See [Group Attributes](#group-attributes) below for details
 


### PR DESCRIPTION
Before the changes implemented in this PR, users were forced to include a block in their `vcfa_provider_ldap` or `vcfa_org_ldap` definitions:

```
lifecycle {
    ignore_changes = [password]
}
```

With these changes, this requirement is no more. The idea is to save the LDAP password as the user provides it on create/update, ignoring the backend in this case (which never returns it). On reads, we just recover the value from state.

If the password is changed, the mechanism works exactly the same, so it detects password changes as normal.

Acceptance tests:

```
go test -tags functional -run '^TestAcc.*Ldap' -v -timeout 0
```

Manual checks:

- Create `vcfa_provider_ldap` and `vcfa_org_ldap` HCL blocks. Apply as usual **without any `lifecycle` meta-argument**.
- Run `terraform plan`. No updates-in-place should be reported.
- Update the password to a dumb one that does not work. It should report the update-in-place and apply.
- In UI, try to *Sync* ("Sync" button). Task should fail.
- Try to revert back to correct password. It should report the update-in-place and apply.
- In UI, try to *Sync* ("Sync" button). Task should finish OK.
- Destroy