### PR TITLE
Amend PR 72

### DIFF
--- a/.changes/v1.0.0/13-features.md
+++ b/.changes/v1.0.0/13-features.md
@@ -1,2 +1,2 @@
-* **New Resource:** `vcfa_content_library_item` to manage Content Library Items [GH-13, GH-46, GH-50, GH-53, GH-66]
+* **New Resource:** `vcfa_content_library_item` to manage Content Library Items [GH-13, GH-46, GH-50, GH-53, GH-66, GH-75]
 * **New Data Source:** `vcfa_content_library_item` to read Content Library Items [GH-13, GH-66]

--- a/vcfa/config_test.go
+++ b/vcfa/config_test.go
@@ -1,4 +1,4 @@
-//go:build api || functional || tm || cci || ALL
+//go:build api || functional || tm || cci || contentlibrary || org || ALL
 
 package vcfa
 

--- a/vcfa/provider_test.go
+++ b/vcfa/provider_test.go
@@ -1,4 +1,4 @@
-//go:build api || functional || tm || cci || ALL
+//go:build api || functional || tm || cci || contentlibrary || org || ALL
 
 package vcfa
 

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -519,7 +519,7 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 	})
 }
 
-const testAccVcfaContentLibraryTenantPrerequisites = testAccVcfaContentLibraryPrerequisites + `
+const testAccVcfaContentLibraryTenantPrerequisites = `
 resource "vcfa_org" "test" {
   provider     = vcfa
   name         = "{{.Org}}"
@@ -592,7 +592,7 @@ resource "vcfa_org_region_quota" "test" {
 }
 `
 
-const testAccVcfaContentLibraryTenantStep1 = testAccVcfaContentLibraryTenantPrerequisites + `
+const testAccVcfaContentLibraryTenantStep1 = testAccVcfaContentLibraryPrerequisites + testAccVcfaContentLibraryTenantPrerequisites + `
 data "vcfa_storage_class" "sc" {
   provider  = vcfa
   region_id = {{.RegionId}}

--- a/vcfa/testcheck_funcs_test.go
+++ b/vcfa/testcheck_funcs_test.go
@@ -1,4 +1,4 @@
-//go:build api || functional || tm || cci || ALL
+//go:build api || functional || tm || cci || contentlibrary || org || ALL
 
 package vcfa
 

--- a/vcfa/vcfa_common_test.go
+++ b/vcfa/vcfa_common_test.go
@@ -1,4 +1,4 @@
-//go:build api || cci || functional || tm || ALL
+//go:build api || cci || functional || tm || contentlibrary || org || ALL
 
 package vcfa
 


### PR DESCRIPTION
This PR fixes a failing test introduced with PR 72, as the Content Library Item (Tenant test) is sharing same HCL as the Content Library. As I introduced vSphere provider, it fails. This PR isolates the vSphere snippet to be used only with Content Library test.

Also fixes some test tags, so one can do:

```
go test -tags contentlibrary -vcfa-skip-priority-tests -vcfa-add-provider -v -timeout 0
```