### PR TITLE
chore(gh): goreleaser v2

### DIFF
--- a/.goreleaser.tmpl
+++ b/.goreleaser.tmpl
@@ -1,0 +1,1 @@
+# Release {{ .Version }} ({{ .Date }})

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,23 +1,20 @@
+---
 version: 2
+
+project_name: terraform-provider-vcfa
+
 before:
-    hooks:
-      - go mod tidy
+  hooks:
+    - go mod tidy
+
 builds:
-  - env:
-      # goreleaser does not work with CGO, it could also complicate
-      # usage by users in CI/CD systems like Terraform Cloud where
-      # they are unable to install libraries.
-      - CGO_ENABLED=0
-    mod_timestamp: '{{ .CommitTimestamp }}'
-    flags:
-      - -trimpath
-    ldflags:
-      - '-s -w -X github.com/vmware/terraform-provider-vcfa/vcfa.BuildVersion={{.Env.BUILDVERSION}}'
+  - id: default
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
     goos:
-      - freebsd
-      - windows
       - linux
+      - windows
       - darwin
+      - freebsd
     goarch:
       - amd64
       - '386'
@@ -26,31 +23,47 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
-    binary: '{{ .ProjectName }}_v{{ .Version }}'
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X github.com/vmware/terraform-provider-vcfa/vcfa.BuildVersion={{.Env.BUILDVERSION}}'
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
 archives:
-  - format: zip
+  - id: default
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    formats: ['zip']
+
 checksum:
-    name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
-    algorithm: sha256
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+
 signs:
-    - artifacts: checksum
-      args:
-        # if you are using this is a GitHub action or some other automated pipeline, you
-        # need to pass the batch flag to indicate its not interactive.
-        - "--batch"
-        - "--local-user"
-        - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
-        - "--output"
-        - "${signature}"
-        - "--detach-sign"
-        - "${artifact}"
+  - id: default
+    artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+
 release:
-    # Visit your project's GitHub Releases page to publish this release.
-    draft: true
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  draft: true
+
 changelog:
-    filters:
-      exclude:
+  filters:
+    exclude:
       - '^docs:'
       - '^test:'
       - Merge pull request

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["5.0"]
+  }
+}


### PR DESCRIPTION
### Description

- Use GoReleaser configuration to v2 without deprecated items.
- Uses the recommended order.
- Add `.goreleaser.yml` for use by a release workflow.
- Add the `terraform-registry-manifest.json` needed for the release workflow. [Reference](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-release-publish#verify-terraform-registry-manifest-file).

Before:

```shell
terraform-provider-vcfa on main
➜ goreleaser check
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

After:

```shell
terraform-provider-vcfa on chore(gh)/goreleaser-v2
➜ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

> [!TIP]
> When you add `.github/workflows/release.yml` the following is recommended.

```yml
---
name: Release

on:
  push:
    tags:
      - "v*"

permissions:
  contents: write

jobs:
  goreleaser:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout Repository
        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
        with:
          fetch-depth: 0
      - name: Setup Go
        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
        with:
          go-version-file: "go.mod"
      - name: Import GPG Key
        id: import_gpg
        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
        with:
          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
          passphrase: ${{ secrets.GPG_PASSPHRASE }}
      - name: Run GoReleaser
        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
        with:
          version: latest
          args: release --clean --timeout 60m --release-header-tmpl .goreleaser.tmpl
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

``` 