### PR TITLE
Run namesapce test by default

### DIFF
--- a/.changes/v1.0.0/35-features.md
+++ b/.changes/v1.0.0/35-features.md
@@ -1,3 +1,3 @@
-- **New Resource:** `vcfa_supervisor_namespace` to manage Supervisor Namespaces [GH-35, GH-58, GH-59]
+- **New Resource:** `vcfa_supervisor_namespace` to manage Supervisor Namespaces [GH-35, GH-58, GH-59, GH-80]
 - **New Data Source:** `vcfa_supervisor_namespace` to read Supervisor Namespaces [GH-35, GH-58, GH-59]
 - **New Data Source:** `vcfa_kubeconfig` to get Kubeconfig [GH-35, GH-59]

--- a/vcfa/resource_vcfa_supervisor_namespace_test.go
+++ b/vcfa/resource_vcfa_supervisor_namespace_test.go
@@ -9,7 +9,6 @@ package vcfa
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"regexp"
 	"testing"
 
@@ -21,10 +20,6 @@ import (
 )
 
 func TestAccVcfaSupervisorNamespace(t *testing.T) {
-	var executeTest = os.Getenv("VCFA_NAMESPACE_TEST") != ""
-	if !executeTest {
-		t.Skipf("TestAccVcfaSupervisorNamespace not enabled by default. Use 'VCFA_NAMESPACE_TEST=1' to enable")
-	}
 
 	preTestChecks(t)
 	defer postTestChecks(t)


### PR DESCRIPTION
The test `TestAccVcfaSupervisorNamespace` was isolated and required special env variable to be set so that it is triggered.

This PR removes the skip option and runs the test by default.