### PR TITLE
chore(gh): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'    # Match stable releases. e.g. v1.2.3
+      - 'v*.*.*-*'  # Match pre-releases. e.g. v1.2.3-beta, v1.2.3-rc.1
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: go.mod
+      - name: Import GPG Key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        with:
+          version: latest
+          args: release --clean --timeout 60m --release-header-tmpl .goreleaser.tmpl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
Adds the release workflow for the provider.

Will initialize the release workflow when tags for the following are pushed:

```yaml
- 'v*.*.*'    # Match stable releases. e.g. v1.2.3
- 'v*.*.*-*'  # Match pre-releases. e.g. v1.2.3-beta, v1.2.3-rc.1
```