### PR TITLE
chore(gh): add golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,35 @@
+---
+name: golangci-lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.go'
+  push:
+    paths:
+      - '**/*.go'
+  schedule:
+    - cron: 0 0 * * 0
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Download Go Modules
+        run: go mod download
+      - name: Build
+        run: go build -v .
+      - name: Run Linters
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,62 @@
+---
+version: "2"
+
+output:
+  formats:
+    text:
+      path: stdout
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - unconvert
+    - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # TODO: Setting temporary exclusions for specific linters.
+      - linters:
+          - errcheck
+        text: is not checked
+      - linters:
+          - staticcheck
+        text: QF1008
+      - linters:
+          - misspell
+        text: is a misspelling
+      - linters:
+          - revive
+        text: increment-decrement|redefines-builtin-id|unused-parameter|var-declaration|var-naming
+      - linters:
+          - unused
+        text: is unused
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+issues:
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Add `golangci-lint` workflow. This mirrors the configuration we use in our other provider repositories.

> [!IMPORTANT]
> I have added a `TODO:` in the `.golangci.yml` denoting which linters and their items are currently excluded so that the checks pass; however, each should be visited with seperate pull requests to resolve the issue and remove the exclusion. 
>
> Below are the counts without the exclusions:
> 
> ```shell
> 103 issues:
> * errcheck: 7
> * misspell: 4
> * revive: 50
> * staticcheck: 4
> * unused: 38
> ```