### PR TITLE
Fix NPE error when assigning VM Classes that don't specify their name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,3 +85,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/vmware/go-vcloud-director/v3 => github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250603100818-5215e1069b2f

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
-	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.44
+	github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.45
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
 )
@@ -85,5 +85,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v3 => github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250603100818-5215e1069b2f

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250603100818-5215e1069b2f h1:28xwvOozb+9nxL3OcrbL1IKtMqyhpFxDN45my86usUU=
+github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250603100818-5215e1069b2f/go.mod h1:od9X8D09sA7zzsnDNnEOgzT/5OYdKIaNDdULIJneghs=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -192,8 +194,6 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.44 h1:678TePKhfoU0SXV845QmPO8N9BqovfVXghOUv58wBPs=
-github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.44/go.mod h1:invLcnnzb9UKXnzWPCu4O9NUD3niS+7GPOFcKpGqCqY=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250603100818-5215e1069b2f h1:28xwvOozb+9nxL3OcrbL1IKtMqyhpFxDN45my86usUU=
-github.com/adambarreiro/go-vcloud-director/v3 v3.0.0-20250603100818-5215e1069b2f/go.mod h1:od9X8D09sA7zzsnDNnEOgzT/5OYdKIaNDdULIJneghs=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -194,6 +192,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.45 h1:kzO/bNM+50R3EqCDYPb7IKywnRwL0vSajfrGPaIBt9I=
+github.com/vmware/go-vcloud-director/v3 v3.0.0-alpha.45/go.mod h1:od9X8D09sA7zzsnDNnEOgzT/5OYdKIaNDdULIJneghs=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/vcfa/remove_leftovers_test.go
+++ b/vcfa/remove_leftovers_test.go
@@ -38,9 +38,7 @@ var doNotDelete = entityList{
 // alsoDelete contains a list of entities that should be removed , in addition to the ones
 // found by name matching
 // Add to this list if you ever get an entity left behind by a test
-var alsoDelete = entityList{
-	// {Type: "vcfa_xxx", Name: "custom-name", Comment: "manually created"},
-}
+var alsoDelete = entityList{}
 
 // isTest is a regular expression that tells if an entity needs to be deleted
 var isTest = regexp.MustCompile(`^[Tt]est`)


### PR DESCRIPTION
This PR bumps the SDK that contains this fix:

https://github.com/vmware/go-vcloud-director/pull/782

To get rid of the error:

```
Cannot invoke \"com.vmware.vcf.common.model.VirtualMachineClassInvModel.getDetails()\" because \"model\" is null",
  "stackTrace": "java.lang.NullPointerException: Cannot invoke 
```