### PR TITLE
Fix Namespace Class not found

### DIFF
--- a/.changes/v1.0.0/35-features.md
+++ b/.changes/v1.0.0/35-features.md
@@ -1,3 +1,3 @@
-- **New Resource:** `vcfa_supervisor_namespace` to manage Supervisor Namespaces [GH-35, GH-58, GH-59, GH-80, GH-81]
+- **New Resource:** `vcfa_supervisor_namespace` to manage Supervisor Namespaces [GH-35, GH-58, GH-59, GH-80, GH-81, GH-98]
 - **New Data Source:** `vcfa_supervisor_namespace` to read Supervisor Namespaces [GH-35, GH-58, GH-59]
 - **New Data Source:** `vcfa_kubeconfig` to get Kubeconfig [GH-35, GH-59]

--- a/vcfa/config_test.go
+++ b/vcfa/config_test.go
@@ -45,6 +45,9 @@ const (
 // vsphereProviderVersion specifies the version of vSphere Terraform Provider
 var vsphereProviderVersion = "~> 2.11"
 
+// timeProviderVersion specifies the version of Time Terraform Provider
+var timeProviderVersion = "~> 0.13"
+
 func init() {
 
 	// To list the flags when we run "go test -tags functional -vcfa-help", the flag name must start with "vcfa"

--- a/vcfa/config_test.go
+++ b/vcfa/config_test.go
@@ -45,9 +45,6 @@ const (
 // vsphereProviderVersion specifies the version of vSphere Terraform Provider
 var vsphereProviderVersion = "~> 2.11"
 
-// timeProviderVersion specifies the version of Time Terraform Provider
-var timeProviderVersion = "~> 0.13"
-
 func init() {
 
 	// To list the flags when we run "go test -tags functional -vcfa-help", the flag name must start with "vcfa"

--- a/vcfa/resource_vcfa_supervisor_namespace_test.go
+++ b/vcfa/resource_vcfa_supervisor_namespace_test.go
@@ -124,6 +124,7 @@ func TestAccVcfaSupervisorNamespace(t *testing.T) {
 			{
 				ProviderFactories: multipleFactories(),
 				PreConfig: func() {
+					// TODO: Introduce retries when Supervisor Namespace is created, instead of a patch in the test
 					time.Sleep(25 * time.Second) // Give time for Namespace Classes to be allocated after the Organization is created
 					createProject(t, params)
 				}, //Setup project

--- a/vcfa/resource_vcfa_supervisor_namespace_test.go
+++ b/vcfa/resource_vcfa_supervisor_namespace_test.go
@@ -234,7 +234,7 @@ resource "vcfa_org" "test" {
 # Take some time so the Organization can populate Namespace Classes
 resource "time_sleep" "org_wait" {
   depends_on      = [vcfa_org.test]
-  create_duration = "10s"
+  create_duration = "30s"
 }
 
 data "vcfa_role" "org-admin" {

--- a/vcfa/resource_vcfa_supervisor_namespace_test.go
+++ b/vcfa/resource_vcfa_supervisor_namespace_test.go
@@ -117,8 +117,14 @@ func TestAccVcfaSupervisorNamespace(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ProviderFactories: testAccProviders,
-				Config:            configText1,
-				Check:             resource.ComposeTestCheckFunc(),
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"time": {
+						Source:            "hashicorp/time",
+						VersionConstraint: timeProviderVersion,
+					},
+				},
+				Config: configText1,
+				Check:  resource.ComposeTestCheckFunc(),
 			},
 			{
 				ProviderFactories: multipleFactories(),
@@ -223,6 +229,12 @@ resource "vcfa_org" "test" {
   display_name = "terraform-test"
   description  = "terraform test"
   is_enabled   = true
+}
+
+# Take some time so the Organization can populate Namespace Classes
+resource "time_sleep" "org_wait" {
+  depends_on      = [vcfa_org.test]
+  create_duration = "10s"
 }
 
 data "vcfa_role" "org-admin" {


### PR DESCRIPTION
When the Supervisor Namespace is created too fast, it can happen that the Namespace Class is not found.

For 1.1 we may need to introduce retries, better than patching a test.