### PR TITLE
Rename default vpc name to adhere to naming rules

### DIFF
--- a/examples/greenfield/tenant/03-supervisor_namespaces.tf
+++ b/examples/greenfield/tenant/03-supervisor_namespaces.tf
@@ -25,7 +25,7 @@ resource "vcfa_supervisor_namespace" "example" {
   class_name   = "small"
   description  = "Created by Terraform VCFA Provider"
   region_name  = var.region_name
-  vpc_name     = format("%s-%s", var.region_name, "Default-VPC")
+  vpc_name     = format("%s-%s", var.region_name, "default-vpc")
 
   storage_classes_initial_class_config_overrides {
     limit = "200Mi"

--- a/vcfa/resource_vcfa_supervisor_namespace_test.go
+++ b/vcfa/resource_vcfa_supervisor_namespace_test.go
@@ -58,7 +58,7 @@ func TestAccVcfaSupervisorNamespace(t *testing.T) {
 
 		"Supervisor":     testConfig.Tm.VcenterSupervisor,
 		"RegionName":     testConfig.Tm.Region,
-		"VpcName":        testConfig.Tm.Region + "-Default-VPC",
+		"VpcName":        testConfig.Tm.Region + "-default-vpc",
 		"Tier0Gateway":   testConfig.Tm.NsxTier0Gateway,
 		"NsxEdgeCluster": testConfig.Tm.NsxEdgeCluster,
 		"RegionVmClass":  "best-effort-2xlarge",

--- a/vcfa/sample_vcfa_test_config-cci.json
+++ b/vcfa/sample_vcfa_test_config-cci.json
@@ -22,7 +22,7 @@
     "cci": {
         "//": "existing entity configuration that are available in the above defined Org",
         "region": "terraform-demo",
-        "vpc": "terraform-demo-Default-VPC",
+        "vpc": "terraform-demo-default-vpc",
         "storagePolicy": "vSAN Default Storage Policy",
         "supervisorZone": "terraform-demo"
     }

--- a/vcfa/sample_vcfa_test_config.json
+++ b/vcfa/sample_vcfa_test_config.json
@@ -32,7 +32,7 @@
 "cci": {
     "//": "existing entity configuration that are available in the above defined Org",
     "region": "terraform-demo",
-    "vpc": "terraform-demo-Default-VPC",
+    "vpc": "terraform-demo-default-vpc",
     "storagePolicy": "vSAN Default Storage Policy",
     "supervisorZone": "vcfa-gen-wl-vc08-cl1-zone1"
 },


### PR DESCRIPTION
Rename the default VPC name to adhere to RFC1123 naming rules.