### PR TITLE
Only set the Provider Gateway NAT IP config when NAT is enabled

### DIFF
--- a/vcfa/resource_vcfa_provider_gateway.go
+++ b/vcfa/resource_vcfa_provider_gateway.go
@@ -227,10 +227,12 @@ func getProviderGatewayType(tmClient *VCDClient, d *schema.ResourceData) (*types
 		EnableSnat: d.Get("nat_config_enabled").(bool),
 		Logging:    d.Get("nat_config_logging").(bool),
 	}
-	if ipSpaceId, ok := d.GetOk("nat_config_ip_space_id"); ok && ipSpaceId != "" {
-		t.NatConfig.IpSpaceRef = &types.OpenApiReference{ID: ipSpaceId.(string)}
-	} else if d.Get("nat_config_enabled").(bool) {
-		return nil, fmt.Errorf("`nat_config_ip_space_id` is required when `nat_config_enabled` is set to true")
+	if d.Get("nat_config_enabled").(bool) {
+		if ipSpaceId, ok := d.GetOk("nat_config_ip_space_id"); ok && ipSpaceId != "" {
+			t.NatConfig.IpSpaceRef = &types.OpenApiReference{ID: ipSpaceId.(string)}
+		} else {
+			return nil, fmt.Errorf("`nat_config_ip_space_id` is required when `nat_config_enabled` is set to true")
+		}
 	}
 
 	// Update operation fails if the ID is not set for update
@@ -266,10 +268,10 @@ func setProviderGatewayData(tmClient *VCDClient, d *schema.ResourceData, p *govc
 	}
 
 	dSet(d, "nat_config_enabled", p.TmProviderGateway.NatConfig.EnableSnat)
-	dSet(d, "nat_config_logging", p.TmProviderGateway.NatConfig.Logging)
-	if p.TmProviderGateway.NatConfig.IpSpaceRef != nil {
+	if p.TmProviderGateway.NatConfig.EnableSnat && p.TmProviderGateway.NatConfig.IpSpaceRef != nil {
 		dSet(d, "nat_config_ip_space_id", p.TmProviderGateway.NatConfig.IpSpaceRef.ID)
 	}
+	dSet(d, "nat_config_logging", p.TmProviderGateway.NatConfig.Logging)
 
 	// IP Space Associations have to be read separatelly after creation (more details at the top of file)
 	associations, err := tmClient.GetAllTmIpSpaceAssociationsByProviderGatewayId(p.TmProviderGateway.ID)

--- a/vcfa/resource_vcfa_provider_gateway_test.go
+++ b/vcfa/resource_vcfa_provider_gateway_test.go
@@ -102,6 +102,7 @@ func TestAccVcfaProviderGateway(t *testing.T) {
 					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "inbound_remote_networks.#", "0"),
 					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "allow_advertising_private_ip_blocks", "false"),
 					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "nat_config_enabled", "false"),
+					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "nat_config_ip_space_id", ""),
 					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "nat_config_logging", "true"),
 				),
 			},
@@ -118,13 +119,14 @@ func TestAccVcfaProviderGateway(t *testing.T) {
 					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "inbound_remote_networks.#", "1"),
 					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "allow_advertising_private_ip_blocks", "false"),
 					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "nat_config_enabled", "false"),
+					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "nat_config_ip_space_id", ""),
 					resource.TestCheckResourceAttr("vcfa_provider_gateway.test", "nat_config_logging", "false"),
 				),
 			},
 			{
 				Config: configText4,
 				Check: resource.ComposeTestCheckFunc(
-					resourceFieldsEqual("vcfa_provider_gateway.test", "data.vcfa_provider_gateway.test", []string{"nat_config_ip_space_id"}),
+					resourceFieldsEqual("vcfa_provider_gateway.test", "data.vcfa_provider_gateway.test", nil),
 				),
 			},
 			{


### PR DESCRIPTION
The previous PR #175 fix to the `TestAccVcfaProviderGateway` test was incorrect. The issue is not the tests; it's with how we set the NAT IP Space, since we set it regardless of whether NAT was enabled. 

This PR:
* Reverts the previous commit
* Fixes this behavior by setting the NAT IP Space only when NAT is enabled.