### PR TITLE
Update vcfa_content_library properties

### DIFF
--- a/.changes/v1.1.0/180-improvements.md
+++ b/.changes/v1.1.0/180-improvements.md
@@ -1,0 +1,1 @@
+- Update `vcfa_content_library` datasource and resource to allow reading and managing Project Scoped Content Libraries [GH-180]. Added the new attributes `is_project_scoped`. `all_projects_permission`, and `project_permissions`.

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -47,5 +47,5 @@ jobs:
       - name: No VCD references
         run: |
           set +e
-          grep --exclude-dir=.git -ERin "Director|VCD|ources\/tm|labelTm|vcd_tm" . | grep -Eiv "VCDClient|.log:|govcdClient|vcdClient|GOVCD_|govcd.|/director/|directory|github|go-vcloud-director|Directories|Version|VCDHREF|VCDToken"
+          grep --exclude-dir=.git --exclude="go.sum" -ERin "Director|VCD|ources\/tm|labelTm|vcd_tm" . | grep -Eiv "VCDClient|.log:|govcdClient|vcdClient|GOVCD_|govcd.|/director/|directory|github|go-vcloud-director|Directories|Version|VCDHREF|VCDToken"
           if [ "$?" -eq 0 ]; then echo "ERROR: Found some VCD references"; exit 1; else exit 0; fi

--- a/docs/resources/content_library.md
+++ b/docs/resources/content_library.md
@@ -211,6 +211,13 @@ The following arguments are supported:
 - `subscription_config` - (Optional) A block representing subscription settings of a Content Library:
   - `subscription_url` - Subscription URL of this Content Library. For example, a published library from vCenter: `https://my-vcenter/cls/vcsp/lib/972a669e-c668-48f6-91e9-410962befbe4/lib.json`
   - `password` - Password to use to authenticate with the publisher
+- `is_project_scoped` - (Optional) Whether this Content Library is scoped to specific projects in the Organization. Cannot be changed after creation. Only applicable for `TENANT` type Content Libraries.
+- `all_projects_permission` - (Optional) Permissions to apply to all projects in the Organization for this Content Library.
+  Can be `READ_ONLY` or `READ_WRITE`. Only applicable when `is_project_scoped` is set to `true`
+- `project_permissions` - (Optional) A set of project permissions for this Content Library. Only applicable when `is_project_scoped` is set to `true`.
+  Each element has the following:
+  - `permissions` - (Required) The type of project permission (`READ_ONLY` or `READ_WRITE`)
+  - `project_id` - (Required) The ID of the project that this permission applies to
 
 ~> To use `subscription_config` block in `TENANT` type Content Libraries, check that the [`vcfa_org_settings`][vcfa_org_settings]
 of the target Organization allows it.
@@ -223,6 +230,9 @@ of the target Organization allows it.
 - `library_type` - The type of content library, can be either `PROVIDER` (Content Library that is scoped to a provider) or
   `TENANT` (Content Library that is scoped to a tenant organization)
 - `version_number` - Version number of this Content library
+- `status` - Status of this Content Library. Can be `READY`, `NOT_READY`, `FAILED` or `PARTIALLY_READY`
+- `project_permissions` also exports:
+  - `project_name` - The name of the project that this permission applies to
 
 ## Importing
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
-	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -73,7 +73,7 @@ require (
 	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect
-	google.golang.org/grpc v1.79.2 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-version v1.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
-	github.com/vmware/go-vcloud-director/v3 v3.1.0-alpha.2
+	github.com/vmware/go-vcloud-director/v3 v3.1.0-alpha.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
 )

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v3 v3.1.0-alpha.2 h1:eHzPZmg83RXJONQIdyPq/bnrnLRPUu/xLLUeAlvhpoc=
-github.com/vmware/go-vcloud-director/v3 v3.1.0-alpha.2/go.mod h1:xd861iDldQQ4wmf76iqfgY8n2IcWNJoGwfV3D7DVZQI=
+github.com/vmware/go-vcloud-director/v3 v3.1.0-alpha.3 h1:/bCeQV/8lH+Oswe96M/2tQLqlqU5S5J9YlfgzYrSHf0=
+github.com/vmware/go-vcloud-director/v3 v3.1.0-alpha.3/go.mod h1:xd861iDldQQ4wmf76iqfgY8n2IcWNJoGwfV3D7DVZQI=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
-github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
@@ -277,8 +277,8 @@ google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAs
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d h1:t/LOSXPJ9R0B6fnZNyALBRfZBH0Uy0gT+uR+SJ6syqQ=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.79.2 h1:fRMD94s2tITpyJGtBBn7MkMseNpOZU8ZxgC3MMBaXRU=
-google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=

--- a/vcfa/config_test.go
+++ b/vcfa/config_test.go
@@ -29,9 +29,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v3/ccitypes"
 	"github.com/vmware/go-vcloud-director/v3/govcd"
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 	"github.com/vmware/go-vcloud-director/v3/util"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // #nosec G101 -- These credentials are fake for testing purposes
@@ -1450,4 +1452,50 @@ func runPriorityTestsOnce(t *testing.T) {
 
 	priorityTestCleanupFunc = cleanup
 	fmt.Printf("# Continuing run of %s test after priority tests are now done\n", t.Name())
+}
+
+func createProject(t *testing.T, orgName string, username string, password string, projectName string) {
+	tmClient := createTemporaryOrgConnection(orgName, username, password)
+	projectCfg := &ccitypes.Project{
+		TypeMeta: v1.TypeMeta{
+			Kind:       ccitypes.ProjectKind,
+			APIVersion: ccitypes.ProjectAPI + "/" + ccitypes.ProjectVersion,
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: projectName,
+		},
+		Spec: ccitypes.ProjectSpec{
+			Description: fmt.Sprintf("Terraform test project [%s]", projectName),
+		},
+	}
+
+	newProjectAddr, err := tmClient.Client.GetEntityUrl(ccitypes.ProjectsURL)
+	if err != nil {
+		t.Fatalf("error creating URL for new project: %s", err)
+	}
+
+	newProject := &ccitypes.Project{}
+	err = tmClient.Client.PostEntity(newProjectAddr, nil, projectCfg, newProject, nil)
+	if err != nil {
+		t.Fatalf("error creating project %s: %s", projectCfg.Name, err)
+	}
+
+	err = os.Setenv("TF_VAR_project_id", fmt.Sprintf("urn:vcloud:projectAssignment:%s", string(newProject.UID)))
+	if err != nil {
+		t.Fatalf("error setting project_id environment variable: %s", err)
+	}
+}
+
+func removeProject(t *testing.T, orgName string, username string, password string, projectName string) {
+	tmClient := createTemporaryOrgConnection(orgName, username, password)
+
+	projectAddr, err := tmClient.Client.GetEntityUrl(ccitypes.ProjectsURL, "/", projectName)
+	if err != nil {
+		t.Fatalf("error creating URL for get project: %s", err)
+	}
+
+	err = tmClient.Client.DeleteEntity(projectAddr, nil, nil)
+	if err != nil {
+		t.Fatalf("failed removing Project: %s", err)
+	}
 }

--- a/vcfa/datasource_vcfa_content_library.go
+++ b/vcfa/datasource_vcfa_content_library.go
@@ -87,6 +87,45 @@ func datasourceVcfaContentLibrary() *schema.Resource {
 				Computed:    true,
 				Description: fmt.Sprintf("Version number of this %s", labelVcfaContentLibrary),
 			},
+			"is_project_scoped": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: fmt.Sprintf("Whether this %s is scoped to specific projects in the %s", labelVcfaContentLibrary, labelVcfaOrg),
+			},
+			"all_projects_permission": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("Permissions to apply to all projects in the %s for this %s. Can be 'READ_ONLY' or 'READ_WRITE'", labelVcfaOrg, labelVcfaContentLibrary),
+			},
+			"project_permissions": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: fmt.Sprintf("A set of project permissions for this %s", labelVcfaContentLibrary),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"permissions": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of project permission ('READ_ONLY' or 'READ_WRITE')",
+						},
+						"project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the project that this permission applies to",
+						},
+						"project_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the project that this permission applies to",
+						},
+					},
+				},
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("Status of this %s. Can be 'READY', 'NOT_READY', 'FAILED' or 'PARTIALLY_READY'", labelVcfaContentLibrary),
+			},
 		},
 	}
 }

--- a/vcfa/resource_vcfa_content_library.go
+++ b/vcfa/resource_vcfa_content_library.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/go-vcloud-director/v3/govcd"
 	"github.com/vmware/go-vcloud-director/v3/types/v56"
 )
@@ -27,6 +28,7 @@ func resourceVcfaContentLibrary() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceVcfaContentLibraryImport,
 		},
+		CustomizeDiff: resourceVcfaContentLibraryCustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
@@ -123,8 +125,81 @@ func resourceVcfaContentLibrary() *schema.Resource {
 				Computed:    true,
 				Description: fmt.Sprintf("Version number of this %s", labelVcfaContentLibrary),
 			},
+			"is_project_scoped": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: fmt.Sprintf("Whether this %s is scoped to specific projects in the %s", labelVcfaContentLibrary, labelVcfaOrg),
+			},
+			"all_projects_permission": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: fmt.Sprintf("Permissions to apply to all projects in the %s for this %s. Can be 'READ_ONLY' or 'READ_WRITE'. "+
+					"Only applicable when 'is_project_scoped' is set to 'true'", labelVcfaOrg, labelVcfaContentLibrary),
+				ValidateFunc: validation.StringInSlice([]string{"READ_ONLY", "READ_WRITE"}, false),
+			},
+			"project_permissions": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: fmt.Sprintf("A set of project permissions for this %s. Only applicable when 'is_project_scoped' is set to 'true'", labelVcfaContentLibrary),
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"permissions": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "The type of project permission ('READ_ONLY' or 'READ_WRITE')",
+							ValidateFunc: validation.StringInSlice([]string{"READ_ONLY", "READ_WRITE"}, false),
+						},
+						"project_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The ID of the project that this permission applies to",
+						},
+						"project_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the project that this permission applies to",
+						},
+					},
+				},
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("Status of this %s. Can be 'READY', 'NOT_READY', 'FAILED' or 'PARTIALLY_READY'", labelVcfaContentLibrary),
+			},
 		},
 	}
+}
+
+func resourceVcfaContentLibraryCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if d.Get("is_project_scoped").(bool) {
+		hasAllProjectsPermission := false
+		if v, ok := d.GetOk("all_projects_permission"); ok {
+			if s, ok := v.(string); ok && s != "" {
+				hasAllProjectsPermission = true
+			}
+		}
+		hasProjectPermissions := false
+		if v, ok := d.GetOk("project_permissions"); ok {
+			if set, ok := v.(*schema.Set); ok && set != nil && set.Len() > 0 {
+				hasProjectPermissions = true
+			}
+		}
+		if !hasAllProjectsPermission && !hasProjectPermissions {
+			return fmt.Errorf("when %q is true, either %q or %q must be specified", "is_project_scoped", "all_projects_permission", "project_permissions")
+		}
+		return nil
+	}
+	if _, ok := d.GetOk("all_projects_permission"); ok {
+		return fmt.Errorf("%q may only be set when %q is true", "all_projects_permission", "is_project_scoped")
+	}
+	if v, ok := d.GetOk("project_permissions"); ok {
+		if set, ok := v.(*schema.Set); ok && set != nil && set.Len() > 0 {
+			return fmt.Errorf("%q may only be set when %q is true", "project_permissions", "is_project_scoped")
+		}
+	}
+	return nil
 }
 
 func resourceVcfaContentLibraryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -250,10 +325,12 @@ func resourceVcfaContentLibraryImport(_ context.Context, d *schema.ResourceData,
 
 func getContentLibraryType(d *schema.ResourceData) *types.ContentLibrary {
 	t := &types.ContentLibrary{
-		Name:           d.Get("name").(string),
-		Description:    d.Get("description").(string),
-		AutoAttach:     d.Get("auto_attach").(bool),
-		StorageClasses: convertSliceOfStringsToOpenApiReferenceIds(convertTypeListToSliceOfStrings(d.Get("storage_class_ids").(*schema.Set).List())),
+		Name:                  d.Get("name").(string),
+		Description:           d.Get("description").(string),
+		AutoAttach:            d.Get("auto_attach").(bool),
+		StorageClasses:        convertSliceOfStringsToOpenApiReferenceIds(convertTypeListToSliceOfStrings(d.Get("storage_class_ids").(*schema.Set).List())),
+		IsProjectScoped:       d.Get("is_project_scoped").(bool),
+		AllProjectsPermission: d.Get("all_projects_permission").(string),
 	}
 	if v, ok := d.GetOk("subscription_config"); ok {
 		subsConfig := v.([]interface{})[0].(map[string]interface{})
@@ -261,6 +338,18 @@ func getContentLibraryType(d *schema.ResourceData) *types.ContentLibrary {
 			SubscriptionUrl: subsConfig["subscription_url"].(string),
 			Password:        subsConfig["password"].(string),
 		}
+	}
+	if v, ok := d.GetOk("project_permissions"); ok {
+		ppSet := v.(*schema.Set).List()
+		projectPermissions := make([]types.ContentLibraryProjectPermission, len(ppSet))
+		for i, pp := range ppSet {
+			ppMap := pp.(map[string]interface{})
+			projectPermissions[i] = types.ContentLibraryProjectPermission{
+				Permissions:       ppMap["permissions"].(string),
+				ProjectAssignment: types.OpenApiReference{ID: ppMap["project_id"].(string)},
+			}
+		}
+		t.ProjectPermissions = projectPermissions
 	}
 	return t
 }
@@ -278,8 +367,23 @@ func setContentLibraryData(_ *VCDClient, d *schema.ResourceData, cl *govcd.Conte
 	dSet(d, "is_subscribed", cl.ContentLibrary.IsSubscribed)
 	dSet(d, "library_type", cl.ContentLibrary.LibraryType)
 	dSet(d, "version_number", cl.ContentLibrary.VersionNumber)
+	dSet(d, "is_project_scoped", cl.ContentLibrary.IsProjectScoped)
+	dSet(d, "all_projects_permission", cl.ContentLibrary.AllProjectsPermission)
+	dSet(d, "status", cl.ContentLibrary.Status)
 	if cl.ContentLibrary.Org != nil {
 		dSet(d, "org_id", cl.ContentLibrary.Org.ID)
+	}
+
+	projectPermissions := make([]map[string]interface{}, len(cl.ContentLibrary.ProjectPermissions))
+	for i, pp := range cl.ContentLibrary.ProjectPermissions {
+		projectPermissions[i] = map[string]interface{}{
+			"permissions":  pp.Permissions,
+			"project_id":   pp.ProjectAssignment.ID,
+			"project_name": pp.ProjectAssignment.Name,
+		}
+	}
+	if err := d.Set("project_permissions", projectPermissions); err != nil {
+		return err
 	}
 
 	scs := make([]string, len(cl.ContentLibrary.StorageClasses))

--- a/vcfa/resource_vcfa_content_library_test.go
+++ b/vcfa/resource_vcfa_content_library_test.go
@@ -116,6 +116,10 @@ func TestAccVcfaContentLibraryProvider(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "library_type", "PROVIDER"),
 					resource.TestCheckResourceAttr(resourceName, "subscription_config.#", "0"),
 					resource.TestMatchResourceAttr(resourceName, "version_number", regexp.MustCompile("[0-9]")),
+					resource.TestCheckResourceAttr(resourceName, "is_project_scoped", "false"),
+					resource.TestCheckResourceAttr(resourceName, "all_projects_permission", ""),
+					resource.TestCheckResourceAttr(resourceName, "project_permissions.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
 
 					// Subscribed Content Library
 					resource.TestCheckResourceAttr(resourceNameSubscribed, "name", t.Name()+"Subscribed"),
@@ -131,6 +135,10 @@ func TestAccVcfaContentLibraryProvider(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceNameSubscribed, "subscription_config.0.subscription_url", "vsphere_content_library.publisher_content_library", "publication.0.publish_url"),
 					resource.TestCheckResourceAttr(resourceNameSubscribed, "subscription_config.0.password", "password"),
 					resource.TestMatchResourceAttr(resourceNameSubscribed, "version_number", regexp.MustCompile("[0-9]")),
+					resource.TestCheckResourceAttr(resourceNameSubscribed, "is_project_scoped", "false"),
+					resource.TestCheckResourceAttr(resourceNameSubscribed, "all_projects_permission", ""),
+					resource.TestCheckResourceAttr(resourceNameSubscribed, "project_permissions.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceNameSubscribed, "status"),
 				),
 			},
 			{
@@ -294,6 +302,7 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 		"RegionVmClassRefs":   strings.Join(vmClassesRefs, ".id,\n    ") + ".id",
 		"VcfaUrl":             testConfig.Provider.Url,
 		"Tags":                "tm contentlibrary",
+		"ProjectName":         "tf-project",
 	}
 	testParamsNotEmpty(t, params)
 
@@ -329,6 +338,8 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 	cl2 := "vcfa_content_library.cl2"
 	cl3 := "vcfa_content_library.cl3"
 	clSubscribed := "vcfa_content_library.cl_subscribed"
+	clAllProjectsScoped := "vcfa_content_library.cl_all_projects_scoped"
+	clProjectScoped := "vcfa_content_library.cl_project_scoped"
 
 	cachedId := &testCachedFieldValue{}
 
@@ -382,6 +393,10 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 					resource.TestCheckResourceAttr(cl1, "library_type", "TENANT"),
 					resource.TestCheckResourceAttr(cl1, "subscription_config.#", "0"),
 					resource.TestMatchResourceAttr(cl1, "version_number", regexp.MustCompile("[1-9]")),
+					resource.TestCheckResourceAttr(cl1, "is_project_scoped", "false"),
+					resource.TestCheckResourceAttr(cl1, "all_projects_permission", ""),
+					resource.TestCheckResourceAttr(cl1, "project_permissions.#", "0"),
+					resource.TestCheckResourceAttrSet(cl1, "status"),
 
 					// Second content library
 					resource.TestCheckResourceAttr(cl2, "name", t.Name()+"2"),
@@ -395,13 +410,17 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 					resource.TestCheckResourceAttr(cl2, "library_type", "TENANT"),
 					resource.TestCheckResourceAttr(cl2, "subscription_config.#", "0"),
 					resource.TestMatchResourceAttr(cl2, "version_number", regexp.MustCompile("[1-9]")),
+					resource.TestCheckResourceAttr(cl2, "is_project_scoped", "false"),
+					resource.TestCheckResourceAttr(cl2, "all_projects_permission", ""),
+					resource.TestCheckResourceAttr(cl2, "project_permissions.#", "0"),
+					resource.TestCheckResourceAttrSet(cl2, "status"),
 
 					// Subscribed Content Library
 					resource.TestCheckResourceAttr(clSubscribed, "name", t.Name()+"Subscribed"),
 					resource.TestCheckResourceAttrPair(clSubscribed, "org_id", "vcfa_org.test", "id"),
 					resource.TestMatchResourceAttr(clSubscribed, "description", regexp.MustCompile(".*")), // Description is taken from publisher library
 					resource.TestCheckResourceAttr(clSubscribed, "storage_class_ids.#", "1"),
-					resource.TestCheckResourceAttr(clSubscribed, "auto_attach", "true"), // Always true for PROVIDER libraries
+					resource.TestCheckResourceAttr(clSubscribed, "auto_attach", "true"), // Defaults to true for TENANT librariess
 					resource.TestCheckResourceAttrSet(clSubscribed, "creation_date"),
 					resource.TestCheckResourceAttr(clSubscribed, "is_shared", "false"), // Always false for TENANT libraries
 					resource.TestCheckResourceAttr(clSubscribed, "is_subscribed", "true"),
@@ -410,6 +429,10 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 					resource.TestCheckResourceAttrPair(clSubscribed, "subscription_config.0.subscription_url", "vsphere_content_library.publisher_content_library", "publication.0.publish_url"),
 					resource.TestCheckResourceAttr(clSubscribed, "subscription_config.0.password", "password"),
 					resource.TestMatchResourceAttr(clSubscribed, "version_number", regexp.MustCompile("[0-9]")),
+					resource.TestCheckResourceAttr(clSubscribed, "is_project_scoped", "false"),
+					resource.TestCheckResourceAttr(clSubscribed, "all_projects_permission", ""),
+					resource.TestCheckResourceAttr(clSubscribed, "project_permissions.#", "0"),
+					resource.TestCheckResourceAttrSet(clSubscribed, "status"),
 				),
 			},
 			{
@@ -426,7 +449,10 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 			{
 				ProviderFactories: multipleFactories(),
 				ExternalProviders: externalProviders,
-				Config:            configText3,
+				PreConfig: func() {
+					createProject(t, params["Org"].(string), params["Username"].(string), params["Password"].(string), params["ProjectName"].(string))
+				},
+				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Tenant content library
 					resource.TestCheckResourceAttr(cl3, "name", t.Name()+"3"),
@@ -440,6 +466,44 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 					resource.TestCheckResourceAttr(cl3, "library_type", "TENANT"),
 					resource.TestCheckResourceAttr(cl3, "subscription_config.#", "0"),
 					resource.TestMatchResourceAttr(cl3, "version_number", regexp.MustCompile("[1-9]")),
+					resource.TestCheckResourceAttr(cl3, "is_project_scoped", "false"),
+					resource.TestCheckResourceAttr(cl3, "all_projects_permission", ""),
+					resource.TestCheckResourceAttr(cl3, "project_permissions.#", "0"),
+					resource.TestCheckResourceAttrSet(cl3, "status"),
+
+					// Tenant Project Scoped Content Library for all projects in the organization
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "name", t.Name()+"3AllProjectsScoped"),
+					resource.TestCheckResourceAttrPair(clAllProjectsScoped, "org_id", "vcfa_org.test", "id"),
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "storage_class_ids.#", "1"),
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "auto_attach", "true"), // Defaults to true for TENANT libraries
+					resource.TestCheckResourceAttrSet(clAllProjectsScoped, "creation_date"),
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "is_shared", "false"), // Always false for TENANT libraries
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "is_subscribed", "false"),
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "library_type", "TENANT"),
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "subscription_config.#", "0"),
+					resource.TestMatchResourceAttr(clAllProjectsScoped, "version_number", regexp.MustCompile("[1-9]")),
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "is_project_scoped", "true"),
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "all_projects_permission", "READ_ONLY"),
+					resource.TestCheckResourceAttr(clAllProjectsScoped, "project_permissions.#", "0"),
+					resource.TestCheckResourceAttrSet(clAllProjectsScoped, "status"),
+
+					// Tenant Project Scoped Content Library for a specific project in the organization
+					resource.TestCheckResourceAttr(clProjectScoped, "name", t.Name()+"3ProjectScoped"),
+					resource.TestCheckResourceAttrPair(clProjectScoped, "org_id", "vcfa_org.test", "id"),
+					resource.TestCheckResourceAttr(clProjectScoped, "storage_class_ids.#", "1"),
+					resource.TestCheckResourceAttr(clProjectScoped, "auto_attach", "true"), // Defaults to true for TENANT libraries
+					resource.TestCheckResourceAttrSet(clProjectScoped, "creation_date"),
+					resource.TestCheckResourceAttr(clProjectScoped, "is_shared", "false"), // Always false for TENANT libraries
+					resource.TestCheckResourceAttr(clProjectScoped, "is_subscribed", "false"),
+					resource.TestCheckResourceAttr(clProjectScoped, "library_type", "TENANT"),
+					resource.TestCheckResourceAttr(clProjectScoped, "subscription_config.#", "0"),
+					resource.TestMatchResourceAttr(clProjectScoped, "version_number", regexp.MustCompile("[1-9]")),
+					resource.TestCheckResourceAttr(clProjectScoped, "is_project_scoped", "true"),
+					resource.TestCheckResourceAttr(clProjectScoped, "all_projects_permission", ""),
+					resource.TestCheckResourceAttr(clProjectScoped, "project_permissions.#", "1"),
+					resource.TestCheckResourceAttr(clProjectScoped, "project_permissions.0.permissions", "READ_WRITE"),
+					resource.TestCheckResourceAttr(clProjectScoped, "project_permissions.0.project_name", params["ProjectName"].(string)),
+					resource.TestCheckResourceAttrSet(clProjectScoped, "status"),
 				),
 			},
 			{
@@ -482,7 +546,39 @@ func TestAccVcfaContentLibraryTenant(t *testing.T) {
 						"subscription_config.0.%", // Does not have password
 						"subscription_config.0.password",
 					}),
+					resourceFieldsEqual(clAllProjectsScoped, "data.vcfa_content_library.cl_all_projects_scoped_dstenant", []string{
+						"%",
+						"delete_recursive",
+						"delete_force",
+						"subscription_config.0.%", // Does not have password
+						"subscription_config.0.password",
+					}),
+					resourceFieldsEqual(clProjectScoped, "data.vcfa_content_library.cl_project_scoped_dstenant", []string{
+						"%",
+						"delete_recursive",
+						"delete_force",
+						"subscription_config.0.%", // Does not have password
+						"subscription_config.0.password",
+					}),
 				),
+			},
+			{
+				// Shrink config so Terraform destroys tenant libraries that reference the API-created project
+				// (still needed through the datasource step above).
+				ProviderFactories: multipleFactories(),
+				ExternalProviders: externalProviders,
+				Config:            configText2,
+				Check:             resource.ComposeTestCheckFunc(),
+			},
+			{
+				// Project-scoped libraries are gone; safe to delete the project before import (import does not use it).
+				PreConfig: func() {
+					removeProject(t, params["Org"].(string), params["Username"].(string), params["Password"].(string), params["ProjectName"].(string))
+				},
+				ProviderFactories: multipleFactories(),
+				ExternalProviders: externalProviders,
+				Config:            configText2,
+				Check:             resource.ComposeTestCheckFunc(),
 			},
 			{
 				// Note: Without environment variables, this does not work. It complains about
@@ -647,6 +743,10 @@ resource "vcfa_content_library" "cl_subscribed" {
 const testAccVcfaContentLibraryTenantStep3 = testAccVcfaContentLibraryTenantStep1 + `
 # skip-binary-test: Requires an extra provider configuration block with a tenant user
 
+variable "project_id" {
+  type = string
+}
+
 data "vcfa_storage_class" "sc-tenant" {
   provider  = vcfatenant
   region_id = {{.RegionId}}
@@ -669,6 +769,41 @@ resource "vcfa_content_library" "cl3" {
   # but as we created the Region Quota at same time, we need to guarantee dependencies
   # so they are removed correctly afterwards.
   # Also depends on the logged in user.
+  depends_on = [vcfa_org_region_quota.test, vcfa_org_local_user.user]
+}
+
+resource "vcfa_content_library" "cl_all_projects_scoped" {
+  provider    = vcfatenant
+  org_id      = vcfa_org.test.id
+  name        = "{{.Name3}}AllProjectsScoped"
+  storage_class_ids = [
+    data.vcfa_storage_class.sc-tenant.id
+  ]
+  delete_force      = true # Should be ignored, otherwise it would fail
+  delete_recursive  = true
+  is_project_scoped = true
+  all_projects_permission = "READ_ONLY"
+
+  # Explicit dependency on Region Quota.
+  depends_on = [vcfa_org_region_quota.test, vcfa_org_local_user.user]
+}
+
+resource "vcfa_content_library" "cl_project_scoped" {
+  provider    = vcfatenant
+  org_id      = vcfa_org.test.id
+  name        = "{{.Name3}}ProjectScoped"
+  storage_class_ids = [
+    data.vcfa_storage_class.sc-tenant.id
+  ]
+  delete_force      = true # Should be ignored, otherwise it would fail
+  delete_recursive  = true
+  is_project_scoped = true
+  project_permissions {
+    permissions = "READ_WRITE"
+    project_id  = var.project_id
+  }
+
+  # Explicit dependency on Region Quota.
   depends_on = [vcfa_org_region_quota.test, vcfa_org_local_user.user]
 }
 `
@@ -704,5 +839,17 @@ data "vcfa_content_library" "cl_subscribed_ds" {
   provider = vcfa
   org_id   = vcfa_org.test.id
   name     = vcfa_content_library.cl_subscribed.name
+}
+
+data "vcfa_content_library" "cl_all_projects_scoped_dstenant" {
+  provider = vcfatenant
+  org_id   = vcfa_org.test.id
+  name     = vcfa_content_library.cl_all_projects_scoped.name
+}
+
+data "vcfa_content_library" "cl_project_scoped_dstenant" {
+  provider = vcfatenant
+  org_id   = vcfa_org.test.id
+  name     = vcfa_content_library.cl_project_scoped.name
 }
 `

--- a/vcfa/resource_vcfa_supervisor_namespace_test.go
+++ b/vcfa/resource_vcfa_supervisor_namespace_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vmware/go-vcloud-director/v3/ccitypes"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAccVcfaSupervisorNamespace(t *testing.T) {
@@ -134,7 +132,7 @@ func TestAccVcfaSupervisorNamespace(t *testing.T) {
 				PreConfig: func() {
 					// TODO: Introduce retries when Supervisor Namespace is created, instead of a patch in the test
 					time.Sleep(70 * time.Second) // Give time for Namespace Classes to be allocated after the Organization is created
-					createProject(t, params)
+					createProject(t, params["OrgName"].(string), params["OrgUser"].(string), params["OrgPassword"].(string), params["ProjectName"].(string))
 				}, //Setup project
 				Config: configText2,
 				Check: resource.ComposeTestCheckFunc(
@@ -205,7 +203,9 @@ func TestAccVcfaSupervisorNamespace(t *testing.T) {
 			},
 			{
 				// Namespace already removed, removing project using SDK and leaving for Terraform to teardwon
-				PreConfig:         func() { removeProject(t, params) },
+				PreConfig: func() {
+					removeProject(t, params["OrgName"].(string), params["OrgUser"].(string), params["OrgPassword"].(string), params["ProjectName"].(string))
+				},
 				ProviderFactories: multipleFactories(),
 				Config:            configText1,
 				Check:             resource.ComposeTestCheckFunc(),
@@ -365,44 +365,3 @@ data "vcfa_kubeconfig" "test-namespace" {
   supervisor_namespace_name = vcfa_supervisor_namespace.test.name
 }
 `
-
-func createProject(t *testing.T, params StringMap) {
-	tmClient := createTemporaryOrgConnection(params["OrgName"].(string), params["OrgUser"].(string), params["OrgPassword"].(string))
-	projectCfg := &ccitypes.Project{
-		TypeMeta: v1.TypeMeta{
-			Kind:       ccitypes.ProjectKind,
-			APIVersion: ccitypes.ProjectAPI + "/" + ccitypes.ProjectVersion,
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name: params["ProjectName"].(string),
-		},
-		Spec: ccitypes.ProjectSpec{
-			Description: fmt.Sprintf("Terraform test project [%s]", params["ProjectName"].(string)),
-		},
-	}
-
-	newProjectAddr, err := tmClient.Client.GetEntityUrl(ccitypes.ProjectsURL)
-	if err != nil {
-		t.Fatalf("error creating URL for new project")
-	}
-
-	newProject := &ccitypes.Project{}
-	// Create
-	err = tmClient.Client.PostEntity(newProjectAddr, nil, projectCfg, newProject, nil)
-	if err != nil {
-		t.Fatalf("error creating project %s: %s", projectCfg.Name, err)
-	}
-}
-
-func removeProject(t *testing.T, params StringMap) {
-	tmClient := createTemporaryOrgConnection(params["OrgName"].(string), params["OrgUser"].(string), params["OrgPassword"].(string))
-
-	projectAddr, err := tmClient.Client.GetEntityUrl(ccitypes.ProjectsURL, "/", params["ProjectName"].(string))
-	if err != nil {
-		t.Fatalf("error getting Project url: %s", err)
-	}
-	err = tmClient.Client.DeleteEntity(projectAddr, nil, nil)
-	if err != nil {
-		t.Fatalf("failed removing Project: %s", err)
-	}
-}


### PR DESCRIPTION
Add the `is_project_scoped`. `all_projects_permission`, and `project_permissions` attributes to the `vcfa_content_library` datasource and resource to allow reading and managing Project Scoped Content Libraries.