### PR TITLE
Update the documentation to clarify that version v1.1.x of the provider requires VCFA 9.1+

### DIFF
--- a/.changes/v1.1.1/208-bug-fixes.md
+++ b/.changes/v1.1.1/208-bug-fixes.md
@@ -1,0 +1,1 @@
+- Update the documentation to clarify that version v1.1.x of the provider requires VCFA 9.1+ [GH-208]

--- a/docs/data-sources/version.md
+++ b/docs/data-sources/version.md
@@ -16,9 +16,9 @@ _Used by: **Provider**_
 ## Example Usage
 
 ```hcl
-# This data source will assert that the VCFA version is exactly 9.0.0, otherwise it will fail
+# This data source will assert that the VCFA version is exactly 9.1.0, otherwise it will fail
 data "vcfa_version" "eq_9" {
-  condition         = "= 9.0.0"
+  condition         = "= 9.1.0"
   fail_if_not_match = true
 }
 
@@ -38,15 +38,15 @@ data "vcfa_version" "lt_91" {
   fail_if_not_match = true
 }
 
-# This data source will assert that the VCFA version is 9.0.X
-data "vcfa_version" "is_90" {
-  condition         = "~> 9.0"
+# This data source will assert that the VCFA version is 9.1.X
+data "vcfa_version" "is_91" {
+  condition         = "~> 9.1"
   fail_if_not_match = true
 }
 
-# This data source will assert that the VCFA version is not 9.1
-data "vcfa_version" "not_91" {
-  condition         = "!= 9.1"
+# This data source will assert that the VCFA version is not 9.0
+data "vcfa_version" "not_90" {
+  condition         = "!= 9.0"
   fail_if_not_match = true
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,6 @@ to track feature additions.
 
 The following VCFA versions are supported by this provider:
 
-- 9.0
 - 9.1
 
 ## Connecting to VCFA
@@ -53,7 +52,7 @@ provider "vcfa" {
 
 # Fetch the VCFA version
 data "vcfa_version" "version" {
-  condition         = ">= 9.0.0"
+  condition         = ">= 9.1.0"
   fail_if_not_match = false
 }
 ```
@@ -73,7 +72,7 @@ provider "vcfa" {
 
 # Fetch the VCFA version
 data "vcfa_version" "version" {
-  condition         = ">= 9.0.0"
+  condition         = ">= 9.1.0"
   fail_if_not_match = false
 }
 ```
@@ -93,7 +92,7 @@ provider "vcfa" {
 
 # Fetch the VCFA version
 data "vcfa_version" "version" {
-  condition         = ">= 9.0.0"
+  condition         = ">= 9.1.0"
   fail_if_not_match = false
 }
 ```

--- a/vcfa/sample_vcfa_test_config.json
+++ b/vcfa/sample_vcfa_test_config.json
@@ -6,7 +6,7 @@
     "//"  : "This section contains credentials related to the VCFA connection of Sys or Org user",
     "user": "serviceadministrator",
     "password": "somePassword",
-    "vcfaVersion": "9.0.0",
+    "vcfaVersion": "9.1.0",
     "apiVersion": "40.0",
     "//": "Access token to be used instead of username/password",
     "token": "",


### PR DESCRIPTION
Update the documentation to clarify that version v1.1.x of the provider requires VCFA 9.1+