### PR TITLE
fix provider org/url schemas inconsistent issue

### DIFF
--- a/.changes/v1.2.1/236-bug-fixes.md
+++ b/.changes/v1.2.1/236-bug-fixes.md
@@ -1,0 +1,1 @@
+- Fix provider `org`/`url` schemas inconsistent issue [GH-236]

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 
 import (
 	"context"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -41,6 +42,29 @@ func (p *VcfaFrameworkProvider) Metadata(_ context.Context, _ provider.MetadataR
 }
 
 func (p *VcfaFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	// The SDKv2 provider (vcfa.Provider()) declares "org" and "url" as Required with an
+	// EnvDefaultFunc fallback. terraform-plugin-sdk's schema-to-protocol conversion flips such
+	// attributes to Optional whenever the environment variable is set (see
+	// helper/schema.Schema.coreConfigSchemaAttribute). Both providers are muxed together and
+	// their schemas must be byte-identical, so this mirrors that same env-dependent behavior here.
+	orgAttribute := schema.StringAttribute{
+		Description: "The VCFA Org for API operations",
+	}
+	if os.Getenv("VCFA_ORG") != "" {
+		orgAttribute.Optional = true
+	} else {
+		orgAttribute.Required = true
+	}
+
+	urlAttribute := schema.StringAttribute{
+		Description: "The VCFA url for VCFA API operations.",
+	}
+	if os.Getenv("VCFA_URL") != "" {
+		urlAttribute.Optional = true
+	} else {
+		urlAttribute.Required = true
+	}
+
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"user": schema.StringAttribute{
@@ -86,14 +110,8 @@ func (p *VcfaFrameworkProvider) Schema(_ context.Context, _ provider.SchemaReque
 				Optional:    true,
 				Description: "The VCFA Org for user authentication",
 			},
-			"org": schema.StringAttribute{
-				Required:    true,
-				Description: "The VCFA Org for API operations",
-			},
-			"url": schema.StringAttribute{
-				Required:    true,
-				Description: "The VCFA url for VCFA API operations.",
-			},
+			"org": orgAttribute,
+			"url": urlAttribute,
 			"allow_unverified_ssl": schema.BoolAttribute{
 				Optional:    true,
 				Description: "If set, VCFAClient will permit unverifiable SSL certificates.",

--- a/vcfa/provider.go
+++ b/vcfa/provider.go
@@ -400,5 +400,9 @@ func validateProviderSchema(d *schema.ResourceData) error {
 		return fmt.Errorf(`both "org" and "sysorg" properties are empty`)
 	}
 
+	if d.Get("url").(string) == "" {
+		return fmt.Errorf(`the "url" property is empty`)
+	}
+
 	return nil
 }


### PR DESCRIPTION
The old sdkv2-based provider declares `org` and `url` as required and also have `DefaultFunc`. The legacy SDKv2-to-protocol conversion has a special rule: if an attribute is `Required` and has a `DefaultFunc`, it evaluates that `DefaultFunc` right when building the schema — if it returns a non-nil value (i.e. the env var is set), the attribute's advertised schema flips to `Required: false` and `Optional: true`.

The new framework-based provider also declares `org` and `url` as required but has no such env-var logic. So:

* No `VCFA_ORG`/`VCFA_URL` set → both schemas say `Required: true` → match, works fine.
* `VCFA_ORG`/`VCFA_URL` set → SDKv2 schema flips to `Optional: true`, but framework schema stays `Required: true` → mismatch error

Fixes #235 